### PR TITLE
feat: PB-106699 Add buffer time before Oauth2 token expiry

### DIFF
--- a/src/SDK/Oauth/Oauth2TokenManager.cs
+++ b/src/SDK/Oauth/Oauth2TokenManager.cs
@@ -7,6 +7,9 @@ namespace OneSpanSign.Sdk.Oauth
 {
     public class Oauth2TokenManager
     {
+
+        public const int AccessTokenExpirationLeeway = 2;
+
         private JsonSerializer objectMapper = new JsonSerializer();
 
         public bool IsOAuth2TokenExpired(string oAuthAccessToken)
@@ -21,7 +24,7 @@ namespace OneSpanSign.Sdk.Oauth
             DateTime tokenExpiresAt = DateTime.UtcNow.AddSeconds(unixEpochTime);
             DateTimeOffset now = DateTimeOffset.Now;
 
-            return now > tokenExpiresAt;
+            return now > tokenExpiresAt.Subtract(TimeSpan.FromSeconds(AccessTokenExpirationLeeway));
         }
     }
 }


### PR DESCRIPTION
In the rare event when oAuth2 token access token expires during the request completion, now Token will be refreshed 2 seconds before it expires