### PR TITLE
fix: PB-109955 Change the usage of UrlTemplate to become thread safe.

### DIFF
--- a/src/SDK/Services/AuditService.cs
+++ b/src/SDK/Services/AuditService.cs
@@ -11,7 +11,7 @@ namespace OneSpanSign.Sdk.Services
 	public class AuditService
     {
         private RestClient restClient;
-        private UrlTemplate template;
+		private string baseUrl;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OneSpanSign.Sdk.AuditService"/> class.
@@ -21,7 +21,7 @@ namespace OneSpanSign.Sdk.Services
         public AuditService (RestClient restClient, string baseUrl)
 		{
             this.restClient = restClient;
-            template = new UrlTemplate(baseUrl);
+			this.baseUrl = baseUrl;
         }
 
 		/// <summary>
@@ -31,7 +31,7 @@ namespace OneSpanSign.Sdk.Services
 		/// <param name="packageId">The package id.</param>
 		public List<Audit> GetAudit (PackageId packageId)
 		{
-			string path = template.UrlFor (UrlTemplate.AUDIT_PATH)
+			string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.AUDIT_PATH)
 				.Replace ("{packageId}", packageId.Id)
 					.Build ();
 

--- a/src/SDK/Services/AuthenticationService.cs
+++ b/src/SDK/Services/AuthenticationService.cs
@@ -10,28 +10,26 @@ namespace OneSpanSign.Sdk
     public class AuthenticationService
     {
         private UnauthenticatedRestClient client;
-        private UrlTemplate webpageTemplate;
-        private UrlTemplate authenticationTemplate;
+        private string webpageUrl;
 
         public AuthenticationService(string webpageUrl)
         {
             client = new UnauthenticatedRestClient();
-            authenticationTemplate = new UrlTemplate(webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH);
-            webpageTemplate = new UrlTemplate(webpageUrl);
+            this.webpageUrl = webpageUrl;
         }
 
         public AuthenticationService (string webpageUrl, ProxyConfiguration proxyConfiguration)
         {
             client = new UnauthenticatedRestClient (proxyConfiguration);
-            authenticationTemplate = new UrlTemplate (webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH);
-            webpageTemplate = new UrlTemplate (webpageUrl);
+            this.webpageUrl = webpageUrl;
         }
 
         public string GetSessionIdForUserAuthenticationToken(string userAuthenticationToken)
         {
-            string path = authenticationTemplate.UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_USER_AUTHENTICATION_TOKEN)
-                                                .Replace("{authenticationToken}", userAuthenticationToken)
-                                                .Build();
+            string path = new UrlTemplate(webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH)
+                                        .UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_USER_AUTHENTICATION_TOKEN)
+                                        .Replace("{authenticationToken}", userAuthenticationToken)
+                                        .Build();
             try {
                 string stringResponse = client.GetUnauthenticated(path);
                 SessionToken userSessionIdToken = JsonConvert.DeserializeObject<SessionToken> (stringResponse);
@@ -48,11 +46,13 @@ namespace OneSpanSign.Sdk
         public string BuildRedirectToDesignerForUserAuthenticationToken(string userAuthenticationToken, PackageId packageId)
         {
             try {
-                string redirectPath = webpageTemplate.UrlFor(UrlTemplate.DESIGNER_REDIRECT_PATH)
+                string redirectPath = new UrlTemplate(webpageUrl)
+                        .UrlFor(UrlTemplate.DESIGNER_REDIRECT_PATH)
                         .Replace("{packageId}", packageId.Id)
                         .Build();
                 string encodedRedirectPath = HttpUtility.UrlEncode(redirectPath);
-                string path = authenticationTemplate.UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_USER_AUTHENTICATION_TOKEN_WITH_REDIRECT)
+                string path = new UrlTemplate(webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH)
+                        .UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_USER_AUTHENTICATION_TOKEN_WITH_REDIRECT)
                         .Replace("{authenticationToken}", userAuthenticationToken)
                         .Replace("{redirectUrl}", encodedRedirectPath)
                         .Build();
@@ -64,7 +64,8 @@ namespace OneSpanSign.Sdk
 
         public string GetSessionIdForSenderAuthenticationToken(string senderAuthenticationToken)
         {
-            string path = authenticationTemplate.UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_SENDER_AUTHENTICATION_TOKEN)
+            string path = new UrlTemplate(webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH)
+                                                .UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_SENDER_AUTHENTICATION_TOKEN)
                                                 .Replace("{senderAuthenticationToken}", senderAuthenticationToken)
                                                 .Build();
             try {
@@ -83,11 +84,13 @@ namespace OneSpanSign.Sdk
         public string BuildRedirectToDesignerForSender(string senderAuthenticationToken, PackageId packageId)
         {
             try {
-                string redirectPath = webpageTemplate.UrlFor(UrlTemplate.DESIGNER_REDIRECT_PATH)
+                string redirectPath = new UrlTemplate(webpageUrl)
+                        .UrlFor(UrlTemplate.DESIGNER_REDIRECT_PATH)
                         .Replace("{packageId}", packageId.Id)
                         .Build();
                 string encodedRedirectPath = HttpUtility.UrlEncode(redirectPath);
-                string path = authenticationTemplate.UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_SENDER_AUTHENTICATION_TOKEN_WITH_REDIRECT)
+                string path = new UrlTemplate(webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH)
+                        .UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_SENDER_AUTHENTICATION_TOKEN_WITH_REDIRECT)
                         .Replace("{senderAuthenticationToken}", senderAuthenticationToken)
                         .Replace("{redirectUrl}", encodedRedirectPath)
                         .Build();
@@ -101,12 +104,14 @@ namespace OneSpanSign.Sdk
         public string BuildRedirectToPackageViewForSender(string userAuthenticationToken, PackageId packageId)
         {
             try {
-                string redirectPath = webpageTemplate.UrlFor(UrlTemplate.PACKAGE_VIEW_REDIRECT_PATH)
-                    .Replace("{packageId}", packageId.Id)
+                string redirectPath = new UrlTemplate(webpageUrl)
+                        .UrlFor(UrlTemplate.PACKAGE_VIEW_REDIRECT_PATH)
+                        .Replace("{packageId}", packageId.Id)
                         .Build();
                 string encodedRedirectPath = HttpUtility.UrlEncode(redirectPath);
-                string path = authenticationTemplate.UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_USER_AUTHENTICATION_TOKEN_WITH_REDIRECT)
-                    .Replace("{authenticationToken}", userAuthenticationToken)
+                string path = new UrlTemplate(webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH)
+                        .UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_USER_AUTHENTICATION_TOKEN_WITH_REDIRECT)
+                        .Replace("{authenticationToken}", userAuthenticationToken)
                         .Replace("{redirectUrl}", encodedRedirectPath)
                         .Build();
 
@@ -118,8 +123,9 @@ namespace OneSpanSign.Sdk
 
         public string GetSessionIdForSignerAuthenticationToken(string signerAuthenticationToken)
         {
-            string path = authenticationTemplate.UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_SIGNER_AUTHENTICATION_TOKEN)
-                .Replace("{signerAuthenticationToken}", signerAuthenticationToken)
+            string path = new UrlTemplate(webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH)
+                    .UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_SIGNER_AUTHENTICATION_TOKEN)
+                    .Replace("{signerAuthenticationToken}", signerAuthenticationToken)
                     .Build();
 
             try {
@@ -138,11 +144,13 @@ namespace OneSpanSign.Sdk
         public string BuildRedirectToSigningForSigner(string signerAuthenticationToken, PackageId packageId)
         {
             try {
-                string redirectPath = webpageTemplate.UrlFor(UrlTemplate.SIGNING_REDIRECT_PATH)
+                string redirectPath = new UrlTemplate(webpageUrl)
+                        .UrlFor(UrlTemplate.SIGNING_REDIRECT_PATH)
                         .Replace("{packageId}", packageId.Id)
                         .Build();
                 string encodedRedirectPath = HttpUtility.UrlEncode(redirectPath);
-                string path = authenticationTemplate.UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_SIGNER_AUTHENTICATION_TOKEN_WITH_REDIRECT)
+                string path = new UrlTemplate(webpageUrl + UrlTemplate.ESL_AUTHENTICATION_PATH)
+                        .UrlFor(UrlTemplate.AUTHENTICATION_PATH_FOR_SIGNER_AUTHENTICATION_TOKEN_WITH_REDIRECT)
                         .Replace("{signerAuthenticationToken}", signerAuthenticationToken)
                         .Replace("{redirectUrl}", encodedRedirectPath)
                         .Build();

--- a/src/SDK/Services/AuthenticationTokenService.cs
+++ b/src/SDK/Services/AuthenticationTokenService.cs
@@ -9,12 +9,12 @@ namespace OneSpanSign.Sdk
     public class AuthenticationTokenService
     {
 		private RestClient restClient;
-		private UrlTemplate template;
+        private string baseUrl;
 
 		public AuthenticationTokenService (RestClient restClient, string baseUrl)
 		{
 			this.restClient = restClient;
-			template = new UrlTemplate (baseUrl);
+            this.baseUrl = baseUrl;
 		}
 
         [Obsolete("call CreateUserAuthenticationToken instead")]
@@ -27,7 +27,7 @@ namespace OneSpanSign.Sdk
 
         public string CreateUserAuthenticationToken ()
         {
-            string path = template.UrlFor (UrlTemplate.USER_AUTHENTICATION_TOKEN_PATH).Build ();
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.USER_AUTHENTICATION_TOKEN_PATH).Build ();
 
             try {
                 string response = restClient.Post(path, "");              
@@ -44,7 +44,7 @@ namespace OneSpanSign.Sdk
         public string CreateSenderAuthenticationToken (PackageId packageId)
         {
             try {
-                string path = template.UrlFor (UrlTemplate.SENDER_AUTHENTICATION_TOKEN_PATH).Build ();
+                string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.SENDER_AUTHENTICATION_TOKEN_PATH).Build ();
                 SenderAuthenticationToken senderAuthenticationToken = new SenderAuthenticationToken();
                 senderAuthenticationToken.PackageId = packageId.Id;
                 string serializedObject = JsonConvert.SerializeObject(senderAuthenticationToken);
@@ -67,7 +67,7 @@ namespace OneSpanSign.Sdk
         public string CreateSignerAuthenticationToken (PackageId packageId, string signerId, IDictionary<string, string> fields)
         {
             try {
-                string path = template.UrlFor (UrlTemplate.SIGNER_AUTHENTICATION_TOKEN_MULTI_USE_PATH).Build ();
+                string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.SIGNER_AUTHENTICATION_TOKEN_MULTI_USE_PATH).Build ();
                 SignerAuthenticationToken signerAuthenticationToken = new SignerAuthenticationToken();
                 signerAuthenticationToken.PackageId = packageId.Id;
                 signerAuthenticationToken.SignerId = signerId;
@@ -88,7 +88,7 @@ namespace OneSpanSign.Sdk
         public string CreateSignerAuthenticationTokenForSingleUse (PackageId packageId, string signerId, IDictionary<string, string> fields)
         {
             try {
-                string path = template.UrlFor (UrlTemplate.SIGNER_AUTHENTICATION_TOKEN_SINGLE_USE_PATH).Build ();
+                string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.SIGNER_AUTHENTICATION_TOKEN_SINGLE_USE_PATH).Build ();
                 SignerAuthenticationToken signerAuthenticationToken = new SignerAuthenticationToken();
                 signerAuthenticationToken.PackageId = packageId.Id;
                 signerAuthenticationToken.SignerId = signerId;

--- a/src/SDK/Services/DataRetentionSettingsService.cs
+++ b/src/SDK/Services/DataRetentionSettingsService.cs
@@ -7,13 +7,13 @@ namespace OneSpanSign.Sdk.Services
 {
     public class DataRetentionSettingsService
     {
-        private UrlTemplate template;
         private RestClient restClient;
+        private string baseUrl;
 
         public DataRetentionSettingsService (RestClient restClient, string baseUrl)
         {
             this.restClient = restClient;
-            template = new UrlTemplate (baseUrl);
+            this.baseUrl = baseUrl;
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace OneSpanSign.Sdk.Services
         /// <returns>Expiry time configuration.</returns>
         public ExpiryTimeConfiguration GetExpiryTimeConfiguration ()
         {
-            String path = template.UrlFor (UrlTemplate.EXPIRY_TIME_CONFIGURATION_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.EXPIRY_TIME_CONFIGURATION_PATH)
                                   .Build ();
             String stringResponse;
             try 
@@ -50,7 +50,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="expiryTimeConfiguration">expiryTimeConfiguration.</param>
         public void SetExpiryTimeConfiguration (ExpiryTimeConfiguration expiryTimeConfiguration)
         {
-            String path = template.UrlFor (UrlTemplate.EXPIRY_TIME_CONFIGURATION_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.EXPIRY_TIME_CONFIGURATION_PATH)
                                   .Build ();
             ExpiryTimeConfigurationConverter converter = new ExpiryTimeConfigurationConverter (expiryTimeConfiguration);
             String expiryTimeConfigurationJson = JsonConvert.SerializeObject(converter.ToAPIExpiryTimeConfiguration ());
@@ -76,7 +76,7 @@ namespace OneSpanSign.Sdk.Services
         /// <returns>Data Management Policy.</returns>
         public DataManagementPolicy GetDataManagementPolicy ()
         {
-            String path = template.UrlFor (UrlTemplate.DATA_MANAGEMENT_POLICY_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.DATA_MANAGEMENT_POLICY_PATH)
                                   .Build ();
             String stringResponse;
             try 
@@ -103,7 +103,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="dataManagementPolicy">dataManagementPolicy.</param>
         public void SetDataManagementPolicy (DataManagementPolicy dataManagementPolicy)
         {
-            String path = template.UrlFor (UrlTemplate.DATA_MANAGEMENT_POLICY_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.DATA_MANAGEMENT_POLICY_PATH)
                                   .Build ();
             DataManagementPolicyConverter converter = new DataManagementPolicyConverter (dataManagementPolicy);
             String dataManagementPolicyJson = JsonConvert.SerializeObject (converter.ToAPIDataManagementPolicy ());

--- a/src/SDK/Services/Internal/AccountApiClient.cs
+++ b/src/SDK/Services/Internal/AccountApiClient.cs
@@ -10,20 +10,20 @@ namespace OneSpanSign.Sdk
 {
     internal class AccountApiClient
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings jsonSettings;
+        private string baseUrl;
 
         public AccountApiClient(RestClient restClient, string apiUrl, JsonSerializerSettings jsonSettings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate(apiUrl);
             this.jsonSettings = jsonSettings;
+            this.baseUrl = apiUrl;
         }
 
         public OneSpanSign.API.Sender InviteUser(OneSpanSign.API.Sender invitee)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_PATH).Build();
             try
             {
                 string json = JsonConvert.SerializeObject(invitee, jsonSettings);
@@ -45,7 +45,7 @@ namespace OneSpanSign.Sdk
 
         public void SendInvite(string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_INVITE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_INVITE_PATH)
                 .Replace("{senderUid}", senderId)
                 .Build();
             try
@@ -65,7 +65,7 @@ namespace OneSpanSign.Sdk
 
         public void UpdateSenderImageSignature(string fileName, byte[] fileContent, string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_SIGNATURE_IMAGE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_SIGNATURE_IMAGE_PATH)
                 .Replace("{senderUid}", senderId)
                 .Build();
             try
@@ -88,7 +88,7 @@ namespace OneSpanSign.Sdk
 
         public OneSpanSign.API.SenderImageSignature GetSenderImageSignature(string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_SIGNATURE_IMAGE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_SIGNATURE_IMAGE_PATH)
                     .Replace("{senderUid}", senderId)
                     .Build();
             try
@@ -109,7 +109,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteSenderImageSignature(string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_SIGNATURE_IMAGE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_SIGNATURE_IMAGE_PATH)
                     .Replace("{senderUid}", senderId)
                     .Build();
             try
@@ -128,7 +128,7 @@ namespace OneSpanSign.Sdk
 
         public void UpdateSender(OneSpanSign.API.Sender apiSender, string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_ID_PATH)
                 .Replace("{senderUid}", senderId)
                 .Build();
             try
@@ -150,7 +150,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteSender(string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_ID_PATH)
                 .Replace("{senderUid}", senderId)
                 .Build();
             try
@@ -170,7 +170,7 @@ namespace OneSpanSign.Sdk
 
         public OneSpanSign.API.Result<OneSpanSign.API.Sender> GetSenders(Direction direction, PageRequest request)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_LIST_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_LIST_PATH)
                 .Replace("{dir}", DirectionUtility.getDirection(direction))
                 .Replace("{from}", request.From.ToString())
                 .Replace("{to}", request.To.ToString())
@@ -197,7 +197,7 @@ namespace OneSpanSign.Sdk
 
         public OneSpanSign.API.Sender GetSender(string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_ID_PATH)
                 .Replace("{senderUid}", senderId)
                 .Build();
             try
@@ -221,7 +221,7 @@ namespace OneSpanSign.Sdk
 
         public IList<OneSpanSign.API.DelegationUser> GetDelegates(string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.DELEGATES_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DELEGATES_PATH)
                 .Replace("{senderId}", senderId)
                 .Build();
 
@@ -245,7 +245,7 @@ namespace OneSpanSign.Sdk
 
         public void UpdateDelegates<T>(string senderId, IList<T> delegateIds)
         {
-            string path = template.UrlFor(UrlTemplate.DELEGATES_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DELEGATES_PATH)
                 .Replace("{senderId}", senderId)
                 .Build();
 
@@ -268,7 +268,7 @@ namespace OneSpanSign.Sdk
 
         public void AddDelegate(string senderId, OneSpanSign.API.DelegationUser delegationUser)
         {
-            string path = template.UrlFor(UrlTemplate.DELEGATE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DELEGATE_ID_PATH)
                 .Replace("{senderId}", senderId)
                 .Replace("{delegateId}", delegationUser.Id)
                 .Build();
@@ -290,7 +290,7 @@ namespace OneSpanSign.Sdk
 
         public void RemoveDelegate(string senderId, string delegateId)
         {
-            string path = template.UrlFor(UrlTemplate.DELEGATE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DELEGATE_ID_PATH)
                 .Replace("{senderId}", senderId)
                 .Replace("{delegateId}", delegateId)
                 .Build();
@@ -311,7 +311,7 @@ namespace OneSpanSign.Sdk
 
         public void ClearDelegates(string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.DELEGATES_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DELEGATES_PATH)
                 .Replace("{senderId}", senderId)
                 .Build();
             try
@@ -332,7 +332,7 @@ namespace OneSpanSign.Sdk
 
         public IList<OneSpanSign.API.Sender> GetContacts()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_CONTACTS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_CONTACTS_PATH)
                 .Build();
             try
             {
@@ -352,7 +352,7 @@ namespace OneSpanSign.Sdk
 
         public IList<VerificationType> getVerificationTypes()
         {
-            String path = template.UrlFor(UrlTemplate.ACCOUNT_VERIFICATION_TYPE_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_VERIFICATION_TYPE_PATH)
                 .Replace("{accountId}", "dummyAccountId")
                 .Build();
 
@@ -376,7 +376,7 @@ namespace OneSpanSign.Sdk
 
         public IList<OneSpanSign.API.Account> getSubAccounts()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_PATH).Build();
             try
             {
                 string response = restClient.Get(path);
@@ -394,7 +394,7 @@ namespace OneSpanSign.Sdk
         
         public IList<OneSpanSign.API.SubAccountApiKey> getSubAccountApiKey()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_SUBACCOUNTAPIKEYS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_SUBACCOUNTAPIKEYS_PATH).Build();
             try
             {
                 string response = restClient.Get(path);
@@ -412,7 +412,7 @@ namespace OneSpanSign.Sdk
 
         public IList<OneSpanSign.API.AccessibleAccountResponse> getAccessibleAccounts()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_ACCESSIBLEACCOUNTS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_ACCESSIBLEACCOUNTS_PATH).Build();
             try
             {
                 string response = restClient.Get(path);
@@ -430,7 +430,7 @@ namespace OneSpanSign.Sdk
 
         public OneSpanSign.API.Account createSubAccount(OneSpanSign.API.SubAccount subAccount)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_PATH).Build();
             try
             {
                 string payload = JsonConvert.SerializeObject(subAccount, jsonSettings);
@@ -449,7 +449,7 @@ namespace OneSpanSign.Sdk
 
         public void updateSubAccount(OneSpanSign.API.SubAccount subAccount, string accountId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SUBACCOUNTS_ID_PATH)
                     .Replace("{accountId}", accountId)
                     .Build();
             try
@@ -506,7 +506,7 @@ namespace OneSpanSign.Sdk
        
                 
         public OneSpanSign.API.Result<API.AccountRole> getAccountRoles() {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_ROLES_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_ROLES_PATH).Build();
             try
             {
                 OneSpanSign.API.Result<OneSpanSign.API.AccountRole> apiResponse =
@@ -526,7 +526,7 @@ namespace OneSpanSign.Sdk
 
         public IList<String> getAccountRoleUsers(String accountRoleId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_ROLES_ROLE_USERS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_ROLES_ROLE_USERS_PATH)
                 .Replace("{accountRoleId}", accountRoleId)
                 .Build();
 
@@ -549,7 +549,7 @@ namespace OneSpanSign.Sdk
 
         public API.AccountRole getAccountRole(String accountRoleId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_ROLES_ROLE_PATH).Replace("{accountRoleId}", accountRoleId)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_ROLES_ROLE_PATH).Replace("{accountRoleId}", accountRoleId)
                 .Build();
 
             try
@@ -571,7 +571,7 @@ namespace OneSpanSign.Sdk
 
         public void addAccountRole(OneSpanSign.API.AccountRole accountRole)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_ROLES_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_ROLES_PATH).Build();
             try
             {
                 string payload = JsonConvert.SerializeObject(accountRole, jsonSettings);
@@ -590,7 +590,7 @@ namespace OneSpanSign.Sdk
 
         public void updateAccountRole(OneSpanSign.API.AccountRole accountRole, string accountRoleId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_ROLES_ROLE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_ROLES_ROLE_PATH)
                 .Replace("{accountRoleId}", accountRoleId)
                 .Build();
             try
@@ -610,7 +610,7 @@ namespace OneSpanSign.Sdk
         }
         public void deleteAccountRole(string accountRoleId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_ROLES_ROLE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_ROLES_ROLE_PATH)
                 .Replace("{accountRoleId}", accountRoleId)
                 .Build();
             try
@@ -631,7 +631,7 @@ namespace OneSpanSign.Sdk
         
         public List<OneSpanSign.API.UserAccountRole> getUserRoles(string userId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_ROLES_PATH).Replace("{userId}", userId)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_ROLES_PATH).Replace("{userId}", userId)
                 .Build();
 
             try
@@ -654,7 +654,7 @@ namespace OneSpanSign.Sdk
         
         public List<OneSpanSign.API.UserAccountRole> getUserRoles(string userId, string accountId)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_ROLE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_ROLE_PATH)
                 .Replace("{userId}", userId)
                 .Replace("{accountId}", accountId)
                 .Build();
@@ -679,7 +679,7 @@ namespace OneSpanSign.Sdk
         
         public void assignAccountRoleToUser(string userId, OneSpanSign.API.UserAccountRole userAccountRole)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_MEMBER_ROLES_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_MEMBER_ROLES_PATH)
                 .Replace("{userId}", userId)
                 .Build();
             try

--- a/src/SDK/Services/Internal/AccountConfigClient.cs
+++ b/src/SDK/Services/Internal/AccountConfigClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using OneSpanSign.API;
@@ -10,20 +11,20 @@ namespace OneSpanSign.Sdk
 {
     internal class AccountConfigClient
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings jsonSettings;
+        private string baseUrl;
 
         public AccountConfigClient(RestClient restClient, string apiUrl, JsonSerializerSettings jsonSettings)
         {
             this.restClient = restClient;
-            this.template = new UrlTemplate(apiUrl);
             this.jsonSettings = jsonSettings;
+            this.baseUrl = apiUrl;
         }
 
         public API.Handover GetHandoverUrl(string language)
         {
-            string path = template.UrlFor(UrlTemplate.HANDOVER_URL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.HANDOVER_URL_PATH)
                 .Replace("{language}", language)
                 .Build();
             try
@@ -44,7 +45,7 @@ namespace OneSpanSign.Sdk
 
         public API.Handover CreateHandoverUrl(string language, API.Handover handover)
         {
-            string path = template.UrlFor(UrlTemplate.HANDOVER_URL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.HANDOVER_URL_PATH)
                 .Replace("{language}", language)
                 .Build();
             try
@@ -67,7 +68,7 @@ namespace OneSpanSign.Sdk
 
         public API.Handover UpdateHandoverUrl(string language, API.Handover handover)
         {
-            string path = template.UrlFor(UrlTemplate.HANDOVER_URL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.HANDOVER_URL_PATH)
                 .Replace("{language}", language)
                 .Build();
             try
@@ -90,7 +91,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteHandoverUrl(string language)
         {
-            string path = template.UrlFor(UrlTemplate.HANDOVER_URL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.HANDOVER_URL_PATH)
                 .Replace("{language}", language)
                 .Build();
             try
@@ -109,7 +110,7 @@ namespace OneSpanSign.Sdk
 
         public IList<string> CreateDeclineReasons(IList<string> declineReasons, string language)
         {
-            string path = template.UrlFor(UrlTemplate.DECLINE_REASONS_PATH).Replace("{language}", language).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DECLINE_REASONS_PATH).Replace("{language}", language).Build();
 
             try
             {
@@ -130,7 +131,7 @@ namespace OneSpanSign.Sdk
 
         public IList<string> UpdateDeclineReasons(IList<string> declineReasons, string language)
         {
-            string path = template.UrlFor(UrlTemplate.DECLINE_REASONS_PATH).Replace("{language}", language)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DECLINE_REASONS_PATH).Replace("{language}", language)
                 .Build();
 
             try
@@ -152,7 +153,7 @@ namespace OneSpanSign.Sdk
 
         public IList<string> GetDeclineReasons(string language)
         {
-            string path = template.UrlFor(UrlTemplate.DECLINE_REASONS_PATH).Replace("{language}", language)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DECLINE_REASONS_PATH).Replace("{language}", language)
                 .Build();
 
             try
@@ -173,7 +174,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteDeclineReasons(string language)
         {
-            string path = template.UrlFor(UrlTemplate.DECLINE_REASONS_PATH).Replace("{language}", language)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DECLINE_REASONS_PATH).Replace("{language}", language)
                 .Build();
 
             try
@@ -194,7 +195,7 @@ namespace OneSpanSign.Sdk
 
         public IList<IdvWorkflowConfiguration> GetIdvWorkflowConfigs()
         {
-            string path = template.UrlFor(UrlTemplate.IDV_WORKFLOW_CONFIGS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.IDV_WORKFLOW_CONFIGS_PATH)
                 .Build();
             try
             {
@@ -214,7 +215,7 @@ namespace OneSpanSign.Sdk
         public IList<IdvWorkflowConfiguration> CreateIdvWorkflowConfigs(
             IList<IdvWorkflowConfiguration> idvWorkflowConfigurations)
         {
-            string path = template.UrlFor(UrlTemplate.IDV_WORKFLOW_CONFIGS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.IDV_WORKFLOW_CONFIGS_PATH)
                 .Build();
             try
             {
@@ -236,7 +237,7 @@ namespace OneSpanSign.Sdk
         public IList<IdvWorkflowConfiguration> UpdateIdvWorkflowConfigs(
             IList<IdvWorkflowConfiguration> idvWorkflowConfigurations)
         {
-            string path = template.UrlFor(UrlTemplate.IDV_WORKFLOW_CONFIGS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.IDV_WORKFLOW_CONFIGS_PATH)
                 .Build();
             try
             {
@@ -257,7 +258,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteIdvWorkflowConfigs()
         {
-            string path = template.UrlFor(UrlTemplate.IDV_WORKFLOW_CONFIGS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.IDV_WORKFLOW_CONFIGS_PATH)
                 .Build();
             try
             {
@@ -275,7 +276,7 @@ namespace OneSpanSign.Sdk
 
         public AccountSettings GetAccountSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SETTINGS_PATH).Build();
             try
             {
                 string stringResponse = restClient.Get(path);
@@ -293,7 +294,7 @@ namespace OneSpanSign.Sdk
 
         public void PatchAccountSettings(AccountSettings accountSettings)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SETTINGS_PATH).Build();
             string payload = JsonConvert.SerializeObject(accountSettings,
                 new JsonSerializerSettings
                 {
@@ -317,7 +318,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteAccountSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SETTINGS_PATH).Build();
 
             try
             {
@@ -335,7 +336,7 @@ namespace OneSpanSign.Sdk
 
         public AccountFeatureSettings GetAccountFeatureSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_FEATURE_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_FEATURE_SETTINGS_PATH).Build();
             try
             {
                 string stringResponse = restClient.Get(path);
@@ -353,7 +354,7 @@ namespace OneSpanSign.Sdk
 
         public void PatchAccountFeatureSettings(AccountFeatureSettings accountFeatureSettings)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_FEATURE_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_FEATURE_SETTINGS_PATH).Build();
             string payload = JsonConvert.SerializeObject(accountFeatureSettings,
                 new JsonSerializerSettings
                 {
@@ -376,7 +377,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteAccountFeatureSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_FEATURE_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_FEATURE_SETTINGS_PATH).Build();
 
             try
             {
@@ -394,7 +395,7 @@ namespace OneSpanSign.Sdk
 
         public AccountPackageSettings GetAccountPackageSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_PACKAGE_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_PACKAGE_SETTINGS_PATH).Build();
             try
             {
                 string stringResponse = restClient.Get(path);
@@ -412,7 +413,7 @@ namespace OneSpanSign.Sdk
 
         public void PatchAccountPackageSettings(AccountPackageSettings accountPackageSettings)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_PACKAGE_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_PACKAGE_SETTINGS_PATH).Build();
             string payload = JsonConvert.SerializeObject(accountPackageSettings,
                 new JsonSerializerSettings
                 {
@@ -435,7 +436,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteAccountPackageSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_PACKAGE_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_PACKAGE_SETTINGS_PATH).Build();
 
             try
             {
@@ -453,7 +454,7 @@ namespace OneSpanSign.Sdk
 
         public AccountDesignerSettings GetAccountDesignerSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_DESIGNER_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_DESIGNER_SETTINGS_PATH).Build();
             try
             {
                 String stringResponse = restClient.Get(path);
@@ -471,7 +472,7 @@ namespace OneSpanSign.Sdk
 
         public void PatchAccountDesignerSettings(AccountDesignerSettings accountDesignerSettings)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_DESIGNER_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_DESIGNER_SETTINGS_PATH).Build();
             string payload = JsonConvert.SerializeObject(accountDesignerSettings,
                 new JsonSerializerSettings
                 {
@@ -494,7 +495,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteAccountDesignerSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_DESIGNER_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_DESIGNER_SETTINGS_PATH).Build();
             try
             {
                 restClient.Delete(path);
@@ -511,7 +512,7 @@ namespace OneSpanSign.Sdk
 
         public AccountEmailReminderSettings GetAccountEmailReminderSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_EMAIL_REMINDER_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_EMAIL_REMINDER_SETTINGS_PATH).Build();
             try
             {
                 String stringResponse = restClient.Get(path);
@@ -529,7 +530,7 @@ namespace OneSpanSign.Sdk
 
         public void PatchAccountEmailReminderSettings(AccountEmailReminderSettings accountEmailReminderSettings)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_EMAIL_REMINDER_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_EMAIL_REMINDER_SETTINGS_PATH).Build();
             string payload = JsonConvert.SerializeObject(accountEmailReminderSettings,
                 new JsonSerializerSettings
                 {
@@ -552,7 +553,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteAccountEmailReminderSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_EMAIL_REMINDER_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_EMAIL_REMINDER_SETTINGS_PATH).Build();
             try
             {
                 restClient.Delete(path);
@@ -569,7 +570,7 @@ namespace OneSpanSign.Sdk
 
         public AccountUploadSettings GetAccountUploadSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_UPLOAD_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_UPLOAD_SETTINGS_PATH).Build();
             try
             {
                 string stringResponse = restClient.Get(path);
@@ -590,7 +591,7 @@ namespace OneSpanSign.Sdk
 
         public void UpdateAccountUploadSettings(AccountUploadSettings accountUploadSettings)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_UPLOAD_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_UPLOAD_SETTINGS_PATH).Build();
             string payload = JsonConvert.SerializeObject(accountUploadSettings.AllowedFileTypes,
                 new JsonSerializerSettings
                 {
@@ -614,7 +615,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteAccountUploadSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_UPLOAD_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_UPLOAD_SETTINGS_PATH).Build();
             try
             {
                 restClient.Delete(path);
@@ -631,7 +632,7 @@ namespace OneSpanSign.Sdk
 
         public AccountSystemSettingProperties GetAccountSystemSettingProperties()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SYSTEM_SETTING_PROPERTIES_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SYSTEM_SETTING_PROPERTIES_PATH).Build();
             try
             {
                 String stringResponse = restClient.Get(path);
@@ -649,7 +650,7 @@ namespace OneSpanSign.Sdk
 
         public void PatchAccountSystemSettingProperties(AccountSystemSettingProperties accountSystemSettingProperties)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SYSTEM_SETTING_PROPERTIES_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SYSTEM_SETTING_PROPERTIES_PATH).Build();
             string payload = JsonConvert.SerializeObject(accountSystemSettingProperties,
                 new JsonSerializerSettings
                 {
@@ -672,7 +673,7 @@ namespace OneSpanSign.Sdk
         
         public void DeleteAccountSystemSettingProperties()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SYSTEM_SETTING_PROPERTIES_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SYSTEM_SETTING_PROPERTIES_PATH).Build();
             try
             {
                 restClient.Delete(path);
@@ -689,7 +690,7 @@ namespace OneSpanSign.Sdk
   
         public SignatureLayout GetSignatureLayout()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SIGNATURE_LAYOUT_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SIGNATURE_LAYOUT_PATH).Build();
             try
             {
                 string stringResponse = restClient.Get(path);
@@ -707,7 +708,7 @@ namespace OneSpanSign.Sdk
 
         public void PatchSignatureLayout(SignatureLayout signatureLayout)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_SIGNATURE_LAYOUT_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_SIGNATURE_LAYOUT_PATH).Build();
             string payload = JsonConvert.SerializeObject(signatureLayout, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver (), Formatting = Formatting.Indented ,NullValueHandling = NullValueHandling.Ignore});
             try
             {
@@ -725,7 +726,7 @@ namespace OneSpanSign.Sdk
   
         public IList<IntegrationFrameworkWorkflow> GetIfWorkflowsConfigs()
         {
-            string path = template.UrlFor(UrlTemplate.IF_WORKFLOW_CONFIGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.IF_WORKFLOW_CONFIGS_PATH).Build();
             try
             {
                 string stringResponse = restClient.Get(path);
@@ -743,7 +744,7 @@ namespace OneSpanSign.Sdk
         
         public SupportedLanguages GetAccountLimitSupportedLanguagesSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_LIMIT_SUPPORTED_LANGUAGES_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_LIMIT_SUPPORTED_LANGUAGES_SETTINGS_PATH).Build();
             try
             {
                 String stringResponse = restClient.Get(path);
@@ -761,7 +762,7 @@ namespace OneSpanSign.Sdk
 
         public void SaveAccountLimitSupportedLanguagesSettings(SupportedLanguages supportedLanguages)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_LIMIT_SUPPORTED_LANGUAGES_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_LIMIT_SUPPORTED_LANGUAGES_SETTINGS_PATH).Build();
             string payload = JsonConvert.SerializeObject(supportedLanguages,
                 new JsonSerializerSettings
                 {
@@ -784,7 +785,7 @@ namespace OneSpanSign.Sdk
         
         public void DeleteAccountLimitSupportedLanguagesSettings()
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_LIMIT_SUPPORTED_LANGUAGES_SETTINGS_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_LIMIT_SUPPORTED_LANGUAGES_SETTINGS_PATH).Build();
             try
             {
                 restClient.Delete(path);

--- a/src/SDK/Services/Internal/ApprovalApiClient.cs
+++ b/src/SDK/Services/Internal/ApprovalApiClient.cs
@@ -8,20 +8,20 @@ namespace OneSpanSign.Sdk
 {
     internal class ApprovalApiClient
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings jsonSettings;
+        private string baseUrl;
 
         public ApprovalApiClient(RestClient restClient, string baseUrl, JsonSerializerSettings jsonSettings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate (baseUrl);
             this.jsonSettings = jsonSettings;
+            this.baseUrl = baseUrl;
         }        
         
         public void DeleteApproval(string packageId, string documentId, string approvalId)
         {
-            string path = template.UrlFor(UrlTemplate.APPROVAL_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.APPROVAL_ID_PATH)
                 .Replace("{packageId}", packageId)
                     .Replace("{documentId}", documentId)
                     .Replace("{approvalId}", approvalId)
@@ -39,7 +39,7 @@ namespace OneSpanSign.Sdk
 
         public string AddApproval(PackageId packageId, string documentId, Approval approval)
         {
-            string path = template.UrlFor(UrlTemplate.APPROVAL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.APPROVAL_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{documentId}", documentId)
                     .Build();
@@ -60,7 +60,7 @@ namespace OneSpanSign.Sdk
 
         public void ModifyApproval(PackageId packageId, string documentId, Approval approval)
         {
-            string path = template.UrlFor(UrlTemplate.APPROVAL_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.APPROVAL_ID_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{documentId}", documentId)
                     .Replace("{approvalId}", approval.Id)
@@ -80,7 +80,7 @@ namespace OneSpanSign.Sdk
 
         public void UpdateApprovals(PackageId packageId, string documentId, IList<Approval> approvalList)
         {
-            string path = template.UrlFor(UrlTemplate.APPROVAL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.APPROVAL_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Replace("{documentId}", documentId)
                 .Build();
@@ -99,7 +99,7 @@ namespace OneSpanSign.Sdk
 
         public Approval GetApproval(PackageId packageId, string documentId, string approvalId)
         {
-            string path = template.UrlFor(UrlTemplate.APPROVAL_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.APPROVAL_ID_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{documentId}", documentId)
                     .Replace("{approvalId}", approvalId)
@@ -120,7 +120,7 @@ namespace OneSpanSign.Sdk
 
         public string AddField(PackageId packageId, string documentId, SignatureId signatureId, OneSpanSign.API.Field field)
         {
-            string path = template.UrlFor(UrlTemplate.FIELD_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.FIELD_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{documentId}", documentId)
                     .Replace("{approvalId}", signatureId.Id)
@@ -142,7 +142,7 @@ namespace OneSpanSign.Sdk
 
         public void ModifyField(PackageId packageId, string documentId, SignatureId signatureId, OneSpanSign.API.Field field)
         {
-            string path = template.UrlFor(UrlTemplate.FIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.FIELD_ID_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{documentId}", documentId)
                     .Replace("{approvalId}", signatureId.Id)
@@ -163,7 +163,7 @@ namespace OneSpanSign.Sdk
 
         public void ModifyConditionalField (PackageId packageId, string documentId, SignatureId signatureId, OneSpanSign.API.ConditionalField field)
         {
-            string path = template.UrlFor (UrlTemplate.CONDITIONAL_FIELD_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.CONDITIONAL_FIELD_PATH)
                 .Replace ("{packageId}", packageId.Id)
                     .Replace ("{documentId}", documentId)
                     .Replace ("{approvalId}", signatureId.Id)
@@ -187,7 +187,7 @@ namespace OneSpanSign.Sdk
 
         public OneSpanSign.API.Field GetField(PackageId packageId, string documentId, SignatureId signatureId, string fieldId)
         {
-            string path = template.UrlFor(UrlTemplate.FIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.FIELD_ID_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{documentId}", documentId)
                     .Replace("{approvalId}", signatureId.Id)
@@ -210,7 +210,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteField(PackageId packageId, string documentId, SignatureId signatureId, string fieldId)
         {
-            string path = template.UrlFor(UrlTemplate.FIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.FIELD_ID_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{documentId}", documentId)
                     .Replace("{approvalId}", signatureId.Id)
@@ -230,7 +230,7 @@ namespace OneSpanSign.Sdk
 
         public IList<Approval> GetAllSignableApprovals(PackageId packageId, string documentId, string signerId)
         {
-            string path = template.UrlFor(UrlTemplate.SIGNABLE_APPROVAL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.SIGNABLE_APPROVAL_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{documentId}", documentId)
                     .Replace("{signerId}", signerId)

--- a/src/SDK/Services/Internal/AttachmentRequirementApiClient.cs
+++ b/src/SDK/Services/Internal/AttachmentRequirementApiClient.cs
@@ -11,21 +11,21 @@ namespace OneSpanSign.Sdk
 {
     internal class AttachmentRequirementApiClient
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings jsonSettings;
+        private string baseUrl;
 
         public AttachmentRequirementApiClient(RestClient restClient, string apiUrl, JsonSerializerSettings jsonSettings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate (apiUrl);            
             this.jsonSettings = jsonSettings;
+            this.baseUrl = apiUrl;
         }
 
         [Obsolete("AcceptAttachment() in AttachmentRequirementApiClient is deprecated, please use AcceptAttachment() in AttachmentRequirementService instead.")]
         public void AcceptAttachment(string packageId, Role role)
         {
-            string path = template.UrlFor(UrlTemplate.UPDATE_SIGNER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.UPDATE_SIGNER_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{roleId}", role.Id)
                 .Build();
@@ -48,7 +48,7 @@ namespace OneSpanSign.Sdk
         [Obsolete("RejectAttachment() in AttachmentRequirementApiClient is deprecated, please use RejectAttachment() in AttachmentRequirementService instead.")]
         public void RejectAttachment(string packageId, Role role)
         {
-            string path = template.UrlFor(UrlTemplate.UPDATE_SIGNER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.UPDATE_SIGNER_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{roleId}", role.Id)
                 .Build();
@@ -76,7 +76,7 @@ namespace OneSpanSign.Sdk
 
         public DownloadedFile DownloadAttachmentFile(string packageId, string attachmentId)
         {
-            string path = template.UrlFor(UrlTemplate.ATTACHMENT_REQUIREMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ATTACHMENT_REQUIREMENT_PATH)
                 .Replace("{packageId}", packageId)
                     .Replace("{attachmentId}", attachmentId)
                     .Build();
@@ -97,7 +97,7 @@ namespace OneSpanSign.Sdk
 
         public DownloadedFile DownloadAttachmentFile(string packageId, string attachmentId, Int32 fileId)
         {
-            string path = template.UrlFor(UrlTemplate.ATTACHMENT_REQUIREMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ATTACHMENT_REQUIREMENT_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{attachmentId}", attachmentId)
                 .Replace("{fileId}", fileId.ToString())
@@ -125,7 +125,7 @@ namespace OneSpanSign.Sdk
 
         public DownloadedFile DownloadAllAttachmentFilesForPackage(string packageId)
         {
-            string path = template.UrlFor(UrlTemplate.ALL_ATTACHMENTS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ALL_ATTACHMENTS_PATH)
                 .Replace("{packageId}", packageId)
                     .Build();
 
@@ -169,7 +169,7 @@ namespace OneSpanSign.Sdk
 
         private DownloadedFile DownloadAllAttachmentsForSignerInPackage(string packageId, string roleId)
         {
-            string path = template.UrlFor(UrlTemplate.ALL_ATTACHMENTS_FOR_ROLE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ALL_ATTACHMENTS_FOR_ROLE_PATH)
                 .Replace("{packageId}", packageId)
                     .Replace("{roleId}", roleId)
                     .Build();
@@ -198,7 +198,7 @@ namespace OneSpanSign.Sdk
         public void UploadAttachment(PackageId packageId, string attachmentId, IDictionary<string, byte[]> files, string signerSessionId)
         {
             RestClient client = new RestClient("");
-            string path = template.UrlFor(UrlTemplate.ATTACHMENT_REQUIREMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ATTACHMENT_REQUIREMENT_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{attachmentId}", attachmentId)
                     .Build();
@@ -225,7 +225,7 @@ namespace OneSpanSign.Sdk
 
         public void DeletaAttachmentFile(PackageId packageId, string attachmentId, Int32 fileId, string signerSessionId)
         {
-            string path = template.UrlFor (UrlTemplate.ATTACHMENT_FILE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ATTACHMENT_FILE_PATH)
                  .Replace ("{packageId}", packageId.Id)
                  .Replace ("{attachmentId}", attachmentId)
                  .Replace("{fileId}", fileId.ToString())

--- a/src/SDK/Services/Internal/CustomFieldApiClient.cs
+++ b/src/SDK/Services/Internal/CustomFieldApiClient.cs
@@ -8,20 +8,20 @@ namespace OneSpanSign.Sdk
 {
     internal class CustomFieldApiClient
     {
-        private UrlTemplate template;
         private RestClient client;
         private JsonSerializerSettings settings;
+        private string baseUrl;
 
         public CustomFieldApiClient(RestClient client, string baseUrl, JsonSerializerSettings settings)
         {
-            template = new UrlTemplate(baseUrl);
             this.client = client;
             this.settings = settings;
+            this.baseUrl = baseUrl;
         }
 
         public bool DoesCustomFieldExist(string id)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_ID_PATH)
                 .Replace("{customFieldId}", id)
                 .Build();
     
@@ -47,7 +47,7 @@ namespace OneSpanSign.Sdk
 
         public bool DoesCustomFieldValueExist(string id)
         {
-            string path = template.UrlFor(UrlTemplate.USER_CUSTOMFIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.USER_CUSTOMFIELD_ID_PATH)
                 .Replace("{customFieldId}", id)
                 .Build();
     
@@ -73,7 +73,7 @@ namespace OneSpanSign.Sdk
         
         public OneSpanSign.API.CustomField CreateCustomField( OneSpanSign.API.CustomField apiField )
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_PATH).Build();
     
             try
             {
@@ -101,7 +101,7 @@ namespace OneSpanSign.Sdk
 
         public OneSpanSign.API.CustomField GetCustomField(string id)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_ID_PATH)
                 .Replace("{customFieldId}", id)
                 .Build();
 
@@ -122,7 +122,7 @@ namespace OneSpanSign.Sdk
 
         public IList<OneSpanSign.API.CustomField> GetCustomFields(Direction direction, PageRequest request)
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_LIST_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_LIST_PATH)
                 .Replace("{dir}", DirectionUtility.getDirection(direction))
                 .Replace("{from}", request.From.ToString())
                 .Replace("{to}", request.To.ToString())
@@ -145,7 +145,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteCustomField( string id )
         {
-            string path = template.UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ACCOUNT_CUSTOMFIELD_ID_PATH)
                 .Replace("{customFieldId}", id)
                 .Build();
 
@@ -165,7 +165,7 @@ namespace OneSpanSign.Sdk
 
         public IList<UserCustomField> GetUserCustomFields()
         {
-            string path = template.UrlFor(UrlTemplate.USER_CUSTOMFIELD_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.USER_CUSTOMFIELD_PATH).Build();
             string response;
 
             try 
@@ -185,7 +185,7 @@ namespace OneSpanSign.Sdk
 
         public UserCustomField GetUserCustomField(string customFieldId)
         {
-            string path = template.UrlFor(UrlTemplate.USER_CUSTOMFIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.USER_CUSTOMFIELD_ID_PATH)
                 .Replace("{customFieldId}", customFieldId)
                 .Build();
 
@@ -207,7 +207,7 @@ namespace OneSpanSign.Sdk
         
         public UserCustomField SubmitCustomFieldValue(UserCustomField apiCustomFieldValue)
         {
-            string path = template.UrlFor(UrlTemplate.USER_CUSTOMFIELD_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.USER_CUSTOMFIELD_PATH).Build();
             string response;
     
             try
@@ -235,7 +235,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteUserCustomField(string id) 
         {
-            string path = template.UrlFor(UrlTemplate.USER_CUSTOMFIELD_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.USER_CUSTOMFIELD_ID_PATH)
                     .Replace("{customFieldId}", id)
                     .Build();
             try 

--- a/src/SDK/Services/Internal/EventNotificationApiClient.cs
+++ b/src/SDK/Services/Internal/EventNotificationApiClient.cs
@@ -8,21 +8,21 @@ namespace OneSpanSign.Sdk
     internal class EventNotificationApiClient
     {
         private RestClient restClient;
-        private UrlTemplate template;
         private JsonSerializerSettings settings;
+        private string baseUrl;
 
         public EventNotificationApiClient(RestClient restClient, string apiUrl, JsonSerializerSettings settings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate(apiUrl);
             this.settings = settings;
+            this.baseUrl = apiUrl;
         }
         
         public void Register(Callback callback)
         {
             try
             {
-                string path = template.UrlFor(UrlTemplate.CALLBACK_PATH).Build();
+                string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.CALLBACK_PATH).Build();
                 string json = JsonConvert.SerializeObject(callback, settings);
 
                 restClient.Post(path, json);
@@ -41,7 +41,7 @@ namespace OneSpanSign.Sdk
         {
             try
             {
-                string path = template.UrlFor(UrlTemplate.CONNECTORS_CALLBACK_PATH)
+                string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.CONNECTORS_CALLBACK_PATH)
                     .Replace("{origin}", origin)
                     .Build();
                 string json = JsonConvert.SerializeObject(callback, settings);
@@ -60,7 +60,7 @@ namespace OneSpanSign.Sdk
 
         public Callback GetEventNotificationConfig()
         {
-            string path = template.UrlFor(UrlTemplate.CALLBACK_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.CALLBACK_PATH).Build();
 
             try
             {
@@ -79,7 +79,7 @@ namespace OneSpanSign.Sdk
 
         public Callback GetEventNotificationConfig(string origin)
         {
-            string path = template.UrlFor(UrlTemplate.CONNECTORS_CALLBACK_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.CONNECTORS_CALLBACK_PATH)
                 .Replace("{origin}", origin)
                 .Build();
 

--- a/src/SDK/Services/Internal/FieldSummaryApiClient.cs
+++ b/src/SDK/Services/Internal/FieldSummaryApiClient.cs
@@ -9,17 +9,17 @@ namespace OneSpanSign.Sdk
     internal class FieldSummaryApiClient
     {
         private RestClient restClient;
-        private UrlTemplate template;
+        private string baseUrl;
 
         public FieldSummaryApiClient(RestClient restClient, string baseUrl)
         {
             this.restClient = restClient;
-            template = new UrlTemplate (baseUrl);                                                                   
+            this.baseUrl = baseUrl;
         }
         
         public List<FieldSummary> GetFieldSummary (string packageId)
         {
-            string path = template.UrlFor (UrlTemplate.FIELD_SUMMARY_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.FIELD_SUMMARY_PATH)
                             .Replace ("{packageId}", packageId)
                             .Build ();
 

--- a/src/SDK/Services/Internal/GroupApiClient.cs
+++ b/src/SDK/Services/Internal/GroupApiClient.cs
@@ -7,27 +7,27 @@ namespace OneSpanSign.Sdk
 {
     internal class GroupApiClient
     {
-        private UrlTemplate template;
         private JsonSerializerSettings settings;
         private RestClient restClient;
+        private string baseUrl;
 
         public GroupApiClient(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate (baseUrl);
+            this.baseUrl = baseUrl;
             this.settings = settings;
         }
 
         public OneSpanSign.API.Result<OneSpanSign.API.Group> GetMyGroups ()
         {
-            string path = template.UrlFor (UrlTemplate.GROUPS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_PATH)
                     .Build ();
             return GetGroups (path);
         }
 
         public OneSpanSign.API.Result<OneSpanSign.API.Group> GetMyGroups (String groupName)
         {
-            string path = template.UrlFor (UrlTemplate.GROUPS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_PATH)
                     .AddParam ("name", groupName)
                     .Build ();
             return GetGroups (path); 
@@ -48,7 +48,7 @@ namespace OneSpanSign.Sdk
         }
         
         public OneSpanSign.API.Group GetGroup( string groupId ) {
-            string path = template.UrlFor (UrlTemplate.GROUPS_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_ID_PATH)
                 .Replace ("{groupId}", groupId)
                     .Build ();
 
@@ -66,7 +66,7 @@ namespace OneSpanSign.Sdk
         }
         
         public OneSpanSign.API.Group CreateGroup( OneSpanSign.API.Group apiGroup ) {
-            string path = template.UrlFor (UrlTemplate.GROUPS_PATH).Build ();
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_PATH).Build ();
             try {
                 string json = JsonConvert.SerializeObject (apiGroup, settings);
                 string response = restClient.Post(path, json);              
@@ -82,7 +82,7 @@ namespace OneSpanSign.Sdk
         }
 
         public OneSpanSign.API.Group UpdateGroup( OneSpanSign.API.Group apiGroup, String groupId ) {
-            string path = template.UrlFor (UrlTemplate.GROUPS_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_ID_PATH)
                 .Replace("{groupId}", groupId)
                 .Build ();
             try {
@@ -100,7 +100,7 @@ namespace OneSpanSign.Sdk
         }
         
         public OneSpanSign.API.GroupMember AddMember( string groupId, OneSpanSign.API.GroupMember apiGroupMember ) {
-            string path = template.UrlFor (UrlTemplate.GROUPS_MEMBER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_MEMBER_PATH)
                 .Replace("{groupId}", groupId )
                 .Build ();
             try {
@@ -118,7 +118,7 @@ namespace OneSpanSign.Sdk
         }
 
         public OneSpanSign.API.Group InviteMember( string groupId, OneSpanSign.API.GroupMember apiGroupMember ) {
-            string path = template.UrlFor (UrlTemplate.GROUPS_INVITE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_INVITE_PATH)
                 .Replace("{groupId}", groupId )
                     .Build ();
             try {
@@ -136,7 +136,7 @@ namespace OneSpanSign.Sdk
         }
         
         public void DeleteGroup( string groupId ) {
-            string path = template.UrlFor (UrlTemplate.GROUPS_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_ID_PATH)
                 .Replace ("{groupId}", groupId)
                 .Build ();
 
@@ -152,7 +152,7 @@ namespace OneSpanSign.Sdk
         }
 
         public OneSpanSign.API.Result<OneSpanSign.API.GroupSummary> GetGroupSummaries() {
-            string path = template.UrlFor (UrlTemplate.GROUPS_SUMMARY_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.GROUPS_SUMMARY_PATH)
                 .Build ();
 
             try {

--- a/src/SDK/Services/Internal/LayoutApiClient.cs
+++ b/src/SDK/Services/Internal/LayoutApiClient.cs
@@ -8,20 +8,20 @@ namespace OneSpanSign.Sdk
 {
     internal class LayoutApiClient
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings settings;
+        private string baseUrl;
 
         public LayoutApiClient(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
-            template = new UrlTemplate(baseUrl);
             this.restClient = restClient;
             this.settings = settings;
+            this.baseUrl = baseUrl;
         }
 
         public string CreateLayout(Package layoutPackage, String packageId)
         {
-            string path = template.UrlFor(UrlTemplate.LAYOUT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.LAYOUT_PATH)
                 .Build();
 
             string packageJson = JsonConvert.SerializeObject(layoutPackage, settings);
@@ -47,7 +47,7 @@ namespace OneSpanSign.Sdk
 
         public Package CreateAndGetLayout(Package layoutPackage, string packageId)
         {
-            string path = template.UrlFor(UrlTemplate.LAYOUT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.LAYOUT_PATH)
                 .Build();
 
             string packageJson = JsonConvert.SerializeObject(layoutPackage, settings);
@@ -72,7 +72,7 @@ namespace OneSpanSign.Sdk
 
         public Result<Package> GetLayouts(Direction direction, PageRequest request)
         {
-            string path = template.UrlFor(UrlTemplate.LAYOUT_LIST_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.LAYOUT_LIST_PATH)
                 .Replace("{dir}", DirectionUtility.getDirection(direction))
                 .Replace("{from}", request.From.ToString())
                 .Replace("{to}", request.To.ToString())
@@ -95,7 +95,7 @@ namespace OneSpanSign.Sdk
 
         public void ApplyLayout(string packageId, string documentId, string layoutId)
         {
-            string path = template.UrlFor(UrlTemplate.APPLY_LAYOUT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.APPLY_LAYOUT_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{documentId}", documentId)
                 .Replace("{layoutId}", layoutId)
@@ -117,7 +117,7 @@ namespace OneSpanSign.Sdk
 
         public void ApplyLayoutByName(string packageId, string documentId, string layoutName)
         {
-            string path = template.UrlFor(UrlTemplate.APPLY_LAYOUT_BY_NAME_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.APPLY_LAYOUT_BY_NAME_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{documentId}", documentId)
                 .Replace("{layoutName}", HttpUtility.UrlEncode(layoutName))

--- a/src/SDK/Services/Internal/QRCodeApiClient.cs
+++ b/src/SDK/Services/Internal/QRCodeApiClient.cs
@@ -7,20 +7,20 @@ namespace OneSpanSign.Sdk
 {
     internal class QRCodeApiClient
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings settings;
+        private string baseUrl;
 
         public QRCodeApiClient(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
-            template = new UrlTemplate(baseUrl);
             this.restClient = restClient;
             this.settings = settings;
+            this.baseUrl = baseUrl;
         }
             
         public string AddQRCode(string packageId, string documentId, OneSpanSign.API.Field apiField)
         {
-            string path = template.UrlFor(UrlTemplate.QRCODE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.QRCODE_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{documentId}", documentId)
                 .Build();
@@ -45,7 +45,7 @@ namespace OneSpanSign.Sdk
 
         public void ModifyQRCode(string packageId, string documentId, OneSpanSign.API.Field apiField)
         {
-            string path = template.UrlFor(UrlTemplate.QRCODE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.QRCODE_ID_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{documentId}", documentId)
                 .Replace("{fieldId}", apiField.Id)
@@ -69,7 +69,7 @@ namespace OneSpanSign.Sdk
 
         public OneSpanSign.API.Field GetQRCode(string packageId, string documentId, string fieldId)
         {
-            string path = template.UrlFor(UrlTemplate.QRCODE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.QRCODE_ID_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{documentId}", documentId)
                 .Replace("{fieldId}", fieldId)
@@ -92,7 +92,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteQRCode(string packageId, string documentId, string fieldId)
         {
-            string path = template.UrlFor(UrlTemplate.QRCODE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.QRCODE_ID_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{documentId}", documentId)
                 .Replace("{fieldId}", fieldId)
@@ -114,7 +114,7 @@ namespace OneSpanSign.Sdk
 
         public void UpdateQRCodes(string packageId, string documentId, IList<OneSpanSign.API.Field> qrCodeList)
         {
-            string path = template.UrlFor(UrlTemplate.QRCODE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.QRCODE_PATH)
                 .Replace("{packageId}", packageId)
                 .Replace("{documentId}", documentId)
                 .Build();

--- a/src/SDK/Services/Internal/ReminderApiClient.cs
+++ b/src/SDK/Services/Internal/ReminderApiClient.cs
@@ -7,20 +7,20 @@ namespace OneSpanSign.Sdk
 {
     internal class ReminderApiClient
     {
-        private UrlTemplate template;
         private JsonSerializerSettings settings;
         private RestClient restClient;
+        private string baseUrl;
 
         public ReminderApiClient(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate (baseUrl);
             this.settings = settings;
+            this.baseUrl = baseUrl;
         }
         
         private string Path( string packageId )
         {
-            return template.UrlFor (UrlTemplate.REMINDER_PATH)
+            return new UrlTemplate(baseUrl).UrlFor (UrlTemplate.REMINDER_PATH)
                 .Replace( "{packageId}", packageId )
                 .Build ();
         }

--- a/src/SDK/Services/Internal/TemplateApiClient.cs
+++ b/src/SDK/Services/Internal/TemplateApiClient.cs
@@ -7,21 +7,21 @@ namespace OneSpanSign.Sdk
 {
     internal class TemplateApiClient
     {
-        private UrlTemplate urls;
         private JsonSerializerSettings settings;
         private RestClient restClient;
+        private string baseUrl;
         
         internal TemplateApiClient(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
             this.restClient = restClient;
-            urls = new UrlTemplate (baseUrl);
             this.settings = settings;
+            this.baseUrl = baseUrl;
         }
         
         internal string CreateTemplateFromPackage(string originalPackageId, OneSpanSign.API.Package delta)
         {
             delta.Type = "TEMPLATE";
-            string path = urls.UrlFor (UrlTemplate.CLONE_PACKAGE_PATH).Replace("{packageId}", originalPackageId)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.CLONE_PACKAGE_PATH).Replace("{packageId}", originalPackageId)
                 .Build ();
             try {
                 string deltaJson = JsonConvert.SerializeObject (delta, settings);
@@ -38,7 +38,7 @@ namespace OneSpanSign.Sdk
         
         internal string CreatePackageFromTemplate(string templateId, OneSpanSign.API.Package delta)
         {
-            string path = urls.UrlFor (UrlTemplate.CLONE_PACKAGE_PATH).Replace("{packageId}", templateId)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.CLONE_PACKAGE_PATH).Replace("{packageId}", templateId)
                 .Build ();
             try {
                 string deltaJson = JsonConvert.SerializeObject (delta, settings);
@@ -56,7 +56,7 @@ namespace OneSpanSign.Sdk
         
         internal string CreateTemplate(OneSpanSign.API.Package template)
         {
-            string path = urls.UrlFor(UrlTemplate.PACKAGE_PATH).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_PATH).Build();
 
             try
             {
@@ -77,7 +77,7 @@ namespace OneSpanSign.Sdk
 
         internal Placeholder AddPlaceholder(PackageId templateId, Placeholder placeholder)
         {
-            string path = urls.UrlFor(UrlTemplate.ROLE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ROLE_PATH)
                 .Replace("{packageId}", templateId.Id)
                     .Build();
             Role apiPayload = new Role();
@@ -103,7 +103,7 @@ namespace OneSpanSign.Sdk
         
         internal Placeholder UpdatePlaceholder(PackageId templateId, Placeholder placeholder)
         {
-            string path = urls.UrlFor(UrlTemplate.ROLE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ROLE_ID_PATH)
                 .Replace("{packageId}", templateId.Id)
                 .Replace("{roleId}", placeholder.Id)
                 .Build();
@@ -129,7 +129,7 @@ namespace OneSpanSign.Sdk
         
         public void Update(OneSpanSign.API.Package apiTemplate)
         {
-            string path = urls.UrlFor(UrlTemplate.PACKAGE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH)
                 .Replace("{packageId}", apiTemplate.Id)
                 .Build();
 

--- a/src/SDK/Services/PackageService.cs
+++ b/src/SDK/Services/PackageService.cs
@@ -20,10 +20,10 @@ namespace OneSpanSign.Sdk.Services
     /// </summary>
     public class PackageService
     {
-        private UrlTemplate template;
         private JsonSerializerSettings settings;
         private RestClient restClient;
         private ReportService reportService;
+        private string baseUrl;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="OneSpanSign.Sdk.PackageService"/> class.
@@ -33,7 +33,7 @@ namespace OneSpanSign.Sdk.Services
         public PackageService(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate(baseUrl);
+            this.baseUrl = baseUrl;
             this.settings = settings;
             reportService = new ReportService(restClient, baseUrl, settings);
         }
@@ -45,7 +45,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="package">The package to create.</param>
         internal PackageId CreatePackage(OneSpanSign.API.Package package)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_PATH)
 				.Build();
             try
             {
@@ -75,7 +75,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="package">The package to create.</param>
         internal PackageId CreatePackageOneStep(OneSpanSign.API.Package package, ICollection<OneSpanSign.Sdk.Document> documents)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_PATH)
             .Build();
             try
             {
@@ -108,7 +108,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="package">The updated package.</param>
         //		internal void UpdatePackage (PackageId packageId, OneSpanSign.API.Package package)
         //		{
-        //			string path = template.UrlFor (UrlTemplate.PACKAGE_ID_PATH)
+        //			string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.PACKAGE_ID_PATH)
         //				.Replace ("{packageId}", packageId.Id)
         //				.Build ();
         //
@@ -127,7 +127,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="packageId">The package id.</param>
         internal OneSpanSign.API.Package GetPackage(PackageId packageId)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH)
 				.Replace("{packageId}", packageId.Id)
 				.Build();
 
@@ -158,7 +158,7 @@ namespace OneSpanSign.Sdk.Services
 
         public void DeleteDocument(PackageId packageId, string documentId)
         {
-            string path = template.UrlFor(UrlTemplate.DOCUMENT_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DOCUMENT_ID_PATH)
 							.Replace("{packageId}", packageId.Id)
 							.Replace("{documentId}", documentId)
 							.Build();
@@ -184,7 +184,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="documentIds">The documents to delete.</param>
         public void DeleteDocuments (PackageId packageId, params string[] documentIds)
         {
-            string path = template.UrlFor (UrlTemplate.DOCUMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.DOCUMENT_PATH)
                             .Replace ("{packageId}", packageId.Id)
                             .Build ();
 
@@ -207,7 +207,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="documentId">Id of document to get.</param>
         public OneSpanSign.Sdk.Document GetDocumentMetadata(DocumentPackage package, string documentId)
         {
-            string path = template.UrlFor(UrlTemplate.DOCUMENT_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DOCUMENT_ID_PATH)
                 .Replace("{packageId}", package.Id.Id)
                 .Replace("{documentId}", documentId)
                 .Build();
@@ -238,7 +238,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="document">The Document to update.</param>
         public void UpdateDocumentMetadata(DocumentPackage package, Document document)
         {
-            string path = template.UrlFor(UrlTemplate.DOCUMENT_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DOCUMENT_ID_PATH)
                 .Replace("{packageId}", package.Id.Id)
                     .Replace("{documentId}", document.Id)
                     .Build();
@@ -288,7 +288,7 @@ namespace OneSpanSign.Sdk.Services
 
         public void OrderDocuments(DocumentPackage package)
         {
-            string path = template.UrlFor(UrlTemplate.DOCUMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DOCUMENT_PATH)
 				.Replace("{packageId}", package.Id.Id)
 				.Build();
 
@@ -323,7 +323,7 @@ namespace OneSpanSign.Sdk.Services
         /// 
         public void AddDocumentWithExternalContent(string packageId, IList<Document> providerDocuments)
         {
-            string path = template.UrlFor(UrlTemplate.DOCUMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DOCUMENT_PATH)
                 .Replace("{packageId}", packageId)
                     .Build();
 
@@ -351,7 +351,7 @@ namespace OneSpanSign.Sdk.Services
 
         public IList<Document> GetDocuments()
         {
-            string path = template.UrlFor(UrlTemplate.PROVIDER_DOCUMENTS).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PROVIDER_DOCUMENTS).Build();
 
             try
             {
@@ -381,7 +381,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="packageId">The package id.</param>
         public void SendPackage(PackageId packageId)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -407,7 +407,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="documentId">The id of the document to download.</param>
         public byte[] DownloadDocument(PackageId packageId, String documentId)
         {
-            string path = template.UrlFor(UrlTemplate.PDF_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PDF_PATH)
 				.Replace("{packageId}", packageId.Id)
 					.Replace("{documentId}", documentId)
 					.Build();
@@ -434,7 +434,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="documentId">Document identifier.</param>
         public byte[] DownloadOriginalDocument(PackageId packageId, String documentId)
         {
-            string path = template.UrlFor(UrlTemplate.ORIGINAL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ORIGINAL_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Replace("{documentId}", documentId)
                 .Build();
@@ -460,7 +460,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="packageId">.</param>
         public byte[] DownloadZippedDocuments(PackageId packageId)
         {
-            string path = template.UrlFor(UrlTemplate.ZIP_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ZIP_PATH)
             .Replace("{packageId}", packageId.Id)
             .Build();
 
@@ -485,7 +485,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="packageId">The package id.</param>
         public byte[] DownloadEvidenceSummary(PackageId packageId)
         {
-            string path = template.UrlFor(UrlTemplate.EVIDENCE_SUMMARY_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.EVIDENCE_SUMMARY_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -505,7 +505,7 @@ namespace OneSpanSign.Sdk.Services
 
         internal void UpdatePackage(PackageId packageId, Package package)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Build();
                 
@@ -526,7 +526,7 @@ namespace OneSpanSign.Sdk.Services
 
         internal void ChangePackageStatusToDraft(PackageId packageId) 
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -553,7 +553,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="document">The document object that has field settings.</param>
         internal Document UploadDocument(PackageId packageId, string fileName, byte[] fileBytes, Document document)
         {
-            string path = template.UrlFor(UrlTemplate.DOCUMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DOCUMENT_PATH)
                 .Replace("{packageId}", packageId.Id)
 				.Build();
 
@@ -585,7 +585,7 @@ namespace OneSpanSign.Sdk.Services
 
         internal IList<Document> UploadDocuments(PackageId packageId, IList<Document> documents)
         {
-            string path = template.UrlFor(UrlTemplate.DOCUMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DOCUMENT_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -645,7 +645,7 @@ namespace OneSpanSign.Sdk.Services
         ///
         internal IList<Document> AddDocumentWithBase64Content(PackageId packageId, IList<Document> documents)
         {
-            string path = template.UrlFor(UrlTemplate.DOCUMENT_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DOCUMENT_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -765,7 +765,7 @@ namespace OneSpanSign.Sdk.Services
 
         public SigningStatus GetSigningStatus(PackageId packageId, string signerId, string documentId)
         {
-            string path = template.UrlFor(UrlTemplate.SIGNING_STATUS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.SIGNING_STATUS_PATH)
 				.Replace("{packageId}", packageId.Id)
 				.Replace("{signerId}", !String.IsNullOrEmpty(signerId) ? signerId : "")
 				.Replace("{documentId}", !String.IsNullOrEmpty(documentId) ? documentId : "")
@@ -795,7 +795,7 @@ namespace OneSpanSign.Sdk.Services
 
         internal IList<Role> GetRoles(PackageId packageId)
         {
-            String path = template.UrlFor(UrlTemplate.ROLE_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ROLE_PATH)
 				.Replace("{packageId}", packageId.Id)
 				.Build();
 
@@ -818,7 +818,7 @@ namespace OneSpanSign.Sdk.Services
 
         public void DeletePackage(PackageId id)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
 
             try
             {
@@ -841,7 +841,7 @@ namespace OneSpanSign.Sdk.Services
                 throw new ArgumentNullException("id");
             }
 
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
 
             try
             {
@@ -864,7 +864,7 @@ namespace OneSpanSign.Sdk.Services
                 throw new ArgumentNullException("id");
             }
 
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
 
             try
             {
@@ -887,7 +887,7 @@ namespace OneSpanSign.Sdk.Services
                 throw new ArgumentNullException("id");
             }
 
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
 
             try
             {
@@ -910,7 +910,7 @@ namespace OneSpanSign.Sdk.Services
                 throw new ArgumentNullException("id");
             }
 
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
 
             try
             {
@@ -933,7 +933,7 @@ namespace OneSpanSign.Sdk.Services
                 throw new ArgumentNullException("id");
             }
 
-            string path = template.UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH).Replace("{packageId}", id.Id).Build();
 
             try
             {
@@ -976,7 +976,7 @@ namespace OneSpanSign.Sdk.Services
         public void NotifySigner(PackageId packageId, string roleId)
         {
 
-            string path = template.UrlFor(UrlTemplate.NOTIFY_ROLE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.NOTIFY_ROLE_PATH)
 				.Replace("{packageId}", packageId.Id)
 				.Replace("{roleId}", roleId)
 				.Build();
@@ -997,7 +997,7 @@ namespace OneSpanSign.Sdk.Services
 
         public void NotifySigner(PackageId packageId, string signerEmail, string message)
         {
-            string path = template.UrlFor(UrlTemplate.NOTIFICATIONS_PATH).Replace("{packageId}", packageId.Id).Build();
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.NOTIFICATIONS_PATH).Replace("{packageId}", packageId.Id).Build();
             StringWriter sw = new StringWriter();
 
             using (JsonWriter json = new JsonTextWriter(sw))
@@ -1027,7 +1027,7 @@ namespace OneSpanSign.Sdk.Services
 
         public Page<DocumentPackage> GetPackages(DocumentPackageStatus status, PageRequest request)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_LIST_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_LIST_PATH)
                 .Replace("{status}", new PackageStatusConverter(status).ToAPIPackageStatus())
 				.Replace("{from}", request.From.ToString())
 				.Replace("{to}", request.To.ToString())
@@ -1054,7 +1054,7 @@ namespace OneSpanSign.Sdk.Services
 
         public Page<Dictionary<String, String>> GetPackagesFields (DocumentPackageStatus status, PageRequest request, ISet<String> fields)
         {
-            string path = template.UrlFor (UrlTemplate.PACKAGE_FIELDS_LIST_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.PACKAGE_FIELDS_LIST_PATH)
                 .Replace ("{status}", new PackageStatusConverter (status).ToAPIPackageStatus ())
                 .Replace ("{from}", request.From.ToString ())
                 .Replace ("{to}", request.To.ToString ())
@@ -1085,7 +1085,7 @@ namespace OneSpanSign.Sdk.Services
             string fromDate = DateHelper.dateToIsoUtcFormat(from);
             string toDate = DateHelper.dateToIsoUtcFormat(to);
 
-            string path = template.UrlFor(UrlTemplate.PACKAGE_LIST_STATUS_DATE_RANGE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_LIST_STATUS_DATE_RANGE_PATH)
                     .Replace("{status}", new PackageStatusConverter(status).ToAPIPackageStatus())
                     .Replace("{from}", request.From.ToString())
                     .Replace("{to}", request.To.ToString())
@@ -1114,7 +1114,7 @@ namespace OneSpanSign.Sdk.Services
 
         public Page<DocumentPackage> GetTemplates(PageRequest request)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_PATH)
                 .AddParam("type", "template")
                 .AddParam("from", request.From.ToString())
                 .AddParam("to", request.To.ToString())
@@ -1125,7 +1125,7 @@ namespace OneSpanSign.Sdk.Services
 
         public Page<DocumentPackage> GetTemplates(PageRequest request, Visibility visibility)
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_PATH)
                 .AddParam("type", "template")
                 .AddParam("from", request.From.ToString())
                 .AddParam("to", request.To.ToString())
@@ -1188,7 +1188,7 @@ namespace OneSpanSign.Sdk.Services
         {
             Role apiPayload = new SignerConverter(signer).ToAPIRole(System.Guid.NewGuid().ToString());
 
-            string path = template.UrlFor(UrlTemplate.ADD_SIGNER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ADD_SIGNER_PATH)
 				.Replace("{packageId}", packageId.Id)
 				.Build();
             try
@@ -1211,7 +1211,7 @@ namespace OneSpanSign.Sdk.Services
 
         public Signer GetSigner(PackageId packageId, string signerId)
         {
-            string path = template.UrlFor(UrlTemplate.GET_SIGNER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.GET_SIGNER_PATH)
 				.Replace("{packageId}", packageId.Id)
 				.Replace("{roleId}", signerId)
 				.Build();
@@ -1236,7 +1236,7 @@ namespace OneSpanSign.Sdk.Services
         {
             Role apiPayload = new SignerConverter(signer).ToAPIRole(System.Guid.NewGuid().ToString());
 
-            string path = template.UrlFor(UrlTemplate.UPDATE_SIGNER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.UPDATE_SIGNER_PATH)
 				.Replace("{packageId}", packageId.Id)
 				.Replace("{roleId}", signer.Id)
 				.Build();
@@ -1257,7 +1257,7 @@ namespace OneSpanSign.Sdk.Services
 
         public void RemoveSigner(PackageId packageId, string signerId)
         {
-            string path = template.UrlFor(UrlTemplate.REMOVE_SIGNER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.REMOVE_SIGNER_PATH)
 				.Replace("{packageId}", packageId.Id)
 				.Replace("{roleId}", signerId)
 				.Build();
@@ -1279,7 +1279,7 @@ namespace OneSpanSign.Sdk.Services
 
         public void OrderSigners(DocumentPackage package)
         {
-            string path = template.UrlFor(UrlTemplate.ROLE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ROLE_PATH)
 				.Replace("{packageId}", package.Id.Id)
 				.Build();
 
@@ -1306,7 +1306,7 @@ namespace OneSpanSign.Sdk.Services
 
         public void UnlockSigner(PackageId packageId, string senderId)
         {
-            string path = template.UrlFor(UrlTemplate.ROLE_UNLOCK_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.ROLE_UNLOCK_PATH)
                 .Replace("{packageId}", packageId.Id)
                     .Replace("{roleId}", senderId)
                     .Build();
@@ -1327,7 +1327,7 @@ namespace OneSpanSign.Sdk.Services
 
         public void ConfigureDocumentVisibility(PackageId packageId, DocumentVisibility visibility)
         {
-            string path = template.UrlFor( UrlTemplate.DOCUMENT_VISIBILITY_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.DOCUMENT_VISIBILITY_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -1350,7 +1350,7 @@ namespace OneSpanSign.Sdk.Services
 
         public DocumentVisibility GetDocumentVisibility(PackageId packageId) 
         {
-            string path = template.UrlFor( UrlTemplate.DOCUMENT_VISIBILITY_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.DOCUMENT_VISIBILITY_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -1466,7 +1466,7 @@ namespace OneSpanSign.Sdk.Services
         private string GetSigningUrl(PackageId packageId, Role role) 
         {
 
-            string path = template.UrlFor(UrlTemplate.SIGNER_URL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.SIGNER_URL_PATH)
                          .Replace("{packageId}", packageId.Id)
                          .Replace("{roleId}", role.Id)
                          .Build();
@@ -1490,7 +1490,7 @@ namespace OneSpanSign.Sdk.Services
         public string StartFastTrack(PackageId packageId, List<FastTrackSigner> signers) 
         {
             string token = GetFastTrackToken(packageId, true);
-            string path = template.UrlFor(UrlTemplate.START_FAST_TRACK_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.START_FAST_TRACK_PATH)
                          .Replace("{token}", token)
                          .Build();
 
@@ -1531,7 +1531,7 @@ namespace OneSpanSign.Sdk.Services
 
         private string GetFastTrackUrl(PackageId packageId, Boolean signing) 
         {
-            string path = template.UrlFor(UrlTemplate.FAST_TRACK_URL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.FAST_TRACK_URL_PATH)
                                   .Replace("{packageId}", packageId.Id)
                                   .Replace("{signing}", signing.ToString())
                                   .Build();
@@ -1560,7 +1560,7 @@ namespace OneSpanSign.Sdk.Services
 
         private void SendSmsToSigner(PackageId packageId, Role role) 
         {
-            string path = template.UrlFor(UrlTemplate.SEND_SMS_TO_SIGNER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.SEND_SMS_TO_SIGNER_PATH)
                                   .Replace("{packageId}", packageId.Id)
                                   .Replace("{roleId}", role.Id)
                                   .Build();
@@ -1583,7 +1583,7 @@ namespace OneSpanSign.Sdk.Services
         {
             List<OneSpanSign.Sdk.NotaryJournalEntry> result = new List<OneSpanSign.Sdk.NotaryJournalEntry>();
 
-            string path = template.UrlFor(UrlTemplate.NOTARY_JOURNAL_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.NOTARY_JOURNAL_PATH)
                     .Replace("{userId}", userId)
                     .Build();
 
@@ -1612,7 +1612,7 @@ namespace OneSpanSign.Sdk.Services
 
         public DownloadedFile GetJournalEntriesAsCSV(string userId) 
         {
-            string path = template.UrlFor(UrlTemplate.NOTARY_JOURNAL_CSV_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.NOTARY_JOURNAL_CSV_PATH)
                     .Replace("{userId}", userId)
                     .Build();
 
@@ -1632,7 +1632,7 @@ namespace OneSpanSign.Sdk.Services
 
         public string GetThankYouDialogContent(PackageId packageId) 
         {
-            string path = template.UrlFor(UrlTemplate.THANK_YOU_DIALOG_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.THANK_YOU_DIALOG_PATH)
                     .Replace("{packageId}", packageId.Id)
                     .Build();
 
@@ -1654,7 +1654,7 @@ namespace OneSpanSign.Sdk.Services
 
         public SupportConfiguration GetConfig(PackageId packageId) 
         {
-            string path = template.UrlFor(UrlTemplate.PACKAGE_INFORMATION_CONFIG_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_INFORMATION_CONFIG_PATH)
                     .Replace("{packageId}", packageId.Id)
                     .Build();
 
@@ -1686,7 +1686,7 @@ namespace OneSpanSign.Sdk.Services
 
         public ReferencedConditions GetReferencedConditions(String packageId, String documentId, String fieldId)
         {
-            String path = template.UrlFor(UrlTemplate.PACKAGE_REFERENCED_CONDITIONS_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_REFERENCED_CONDITIONS_PATH)
                 .Replace("{packageId}", packageId)
                 .AddParam("documentId", documentId)
                 .AddParam("fieldId", fieldId)

--- a/src/SDK/Services/ReportService.cs
+++ b/src/SDK/Services/ReportService.cs
@@ -6,14 +6,14 @@ namespace OneSpanSign.Sdk.Services
 {
     public class ReportService
     {
-        private UrlTemplate template;
         private JsonSerializerSettings settings;
         private RestClient restClient;
+        private string baseUrl;
 
         public ReportService(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate(baseUrl);
+            this.baseUrl = baseUrl;
             this.settings = settings;
         }
 
@@ -22,7 +22,7 @@ namespace OneSpanSign.Sdk.Services
             string toDate = DateHelper.dateToIsoUtcFormat(to);
             string fromDate = DateHelper.dateToIsoUtcFormat(from);
 
-            return template.UrlFor(UrlTemplate.COMPLETION_REPORT_PATH)
+            return new UrlTemplate(baseUrl).UrlFor(UrlTemplate.COMPLETION_REPORT_PATH)
                 .Replace("{from}", fromDate)
                     .Replace("{to}", toDate)
                     .Replace("{status}", new PackageStatusConverter(packageStatus).ToAPIPackageStatus())
@@ -35,7 +35,7 @@ namespace OneSpanSign.Sdk.Services
             string toDate = DateHelper.dateToIsoUtcFormat(to);
             string fromDate = DateHelper.dateToIsoUtcFormat(from);
 
-            return template.UrlFor(UrlTemplate.COMPLETION_REPORT_FOR_ALL_SENDERS_PATH)
+            return new UrlTemplate(baseUrl).UrlFor(UrlTemplate.COMPLETION_REPORT_FOR_ALL_SENDERS_PATH)
                 .Replace("{from}", fromDate)
                     .Replace("{to}", toDate)
                     .Replace("{status}", new PackageStatusConverter(packageStatus).ToAPIPackageStatus())
@@ -47,7 +47,7 @@ namespace OneSpanSign.Sdk.Services
             string toDate = DateHelper.dateToIsoUtcFormat(to);
             string fromDate = DateHelper.dateToIsoUtcFormat(from);
 
-            return template.UrlFor(UrlTemplate.USAGE_REPORT_PATH)
+            return new UrlTemplate(baseUrl).UrlFor(UrlTemplate.USAGE_REPORT_PATH)
                 .Replace("{from}", fromDate)
                     .Replace("{to}", toDate)
                     .Build(); 
@@ -55,7 +55,7 @@ namespace OneSpanSign.Sdk.Services
 
         private string BuildDelegationReportUrl()
         {
-            return template.UrlFor(UrlTemplate.DELEGATION_REPORT_PATH)
+            return new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DELEGATION_REPORT_PATH)
                     .Build(); 
         }
 
@@ -64,7 +64,7 @@ namespace OneSpanSign.Sdk.Services
             string toDate = DateHelper.dateToIsoUtcFormat(to);
             string fromDate = DateHelper.dateToIsoUtcFormat(from);
 
-            return template.UrlFor(UrlTemplate.DELEGATION_REPORT_PATH).Build() + "?from={from}&to={to}"
+            return new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DELEGATION_REPORT_PATH).Build() + "?from={from}&to={to}"
                     .Replace("{from}", fromDate)
                     .Replace("{to}", toDate); 
         }
@@ -74,7 +74,7 @@ namespace OneSpanSign.Sdk.Services
             string toDate = DateHelper.dateToIsoUtcFormat(to);
             string fromDate = DateHelper.dateToIsoUtcFormat(from);
 
-            return template.UrlFor(UrlTemplate.DELEGATION_REPORT_PATH).Build() + "?senderId={senderId}&from={from}&to={to}"
+            return new UrlTemplate(baseUrl).UrlFor(UrlTemplate.DELEGATION_REPORT_PATH).Build() + "?senderId={senderId}&from={from}&to={to}"
                 .Replace("{senderId}", senderId)
                 .Replace("{from}", fromDate)
                 .Replace("{to}", toDate); 

--- a/src/SDK/Services/SessionService.cs
+++ b/src/SDK/Services/SessionService.cs
@@ -10,17 +10,17 @@ namespace OneSpanSign.Sdk.Services
 	/// </summary>
 	public class SessionService
 	{
-		private UrlTemplate template;
 		private AuthenticationTokenService authenticationService;
 		private RestClient restClient;
+		private string baseUrl;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="OneSpanSign.Sdk.SessionService"/> class.
 		/// </summary>
         public SessionService(RestClient client, string baseUrl)
         {
-            template = new UrlTemplate(baseUrl);
             this.restClient = client;
+			this.baseUrl = baseUrl;
         }
 
         public SessionToken CreateSessionToken (PackageId packageId, string signerId)
@@ -44,7 +44,7 @@ namespace OneSpanSign.Sdk.Services
 		public SessionToken CreateSignerSessionToken (PackageId packageId, string signerId)
 		{
 
-			string path = template.UrlFor (UrlTemplate.SESSION_PATH)
+			string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.SESSION_PATH)
                 .Replace ("{packageId}", packageId.Id)
                 .Replace ("{signerId}", HttpUtility.UrlEncode(signerId))
                 .Build ();

--- a/src/SDK/Services/SignatureImageService.cs
+++ b/src/SDK/Services/SignatureImageService.cs
@@ -6,20 +6,20 @@ namespace OneSpanSign.Sdk
 {
     public class SignatureImageService
     {
-        private UrlTemplate template;
         private JsonSerializerSettings settings;
         private RestClient client;
+        private string baseUrl;
 
         public SignatureImageService(RestClient client, string baseUrl, JsonSerializerSettings settings)
         {
             this.client = client;
-            template = new UrlTemplate(baseUrl);
+            this.baseUrl = baseUrl;
             this.settings = settings;
         }
 
         public DownloadedFile GetSignatureImageForSender(string senderId, SignatureImageFormat format) 
         {
-            string path = template.UrlFor( UrlTemplate.SIGNATURE_IMAGE_FOR_SENDER_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.SIGNATURE_IMAGE_FOR_SENDER_PATH)
                 .Replace("{senderId}", senderId)
                 .Build();
             try 
@@ -38,7 +38,7 @@ namespace OneSpanSign.Sdk
 
         public DownloadedFile GetSignatureImageForPackageRole(PackageId packageId, string signerId, SignatureImageFormat format) 
         {
-            string path = template.UrlFor(UrlTemplate.SIGNATURE_IMAGE_FOR_PACKAGE_ROLE_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.SIGNATURE_IMAGE_FOR_PACKAGE_ROLE_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Replace("{roleId}", signerId)
                 .Build();

--- a/src/SDK/Services/SignerVerificationService.cs
+++ b/src/SDK/Services/SignerVerificationService.cs
@@ -6,20 +6,20 @@ namespace OneSpanSign.Sdk
 {
     public class SignerVerificationService
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings settings;
+        private string baseUrl;
 
         public SignerVerificationService(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
-            this.template = new UrlTemplate( baseUrl );
             this.restClient = restClient;
             this.settings = settings;
+            this.baseUrl = baseUrl;
         }
 
         internal void CreateSignerVerification( PackageId packageId, string roleId , OneSpanSign.API.Verification verification) 
         {
-            string path = template.UrlFor( UrlTemplate.ADD_SIGNER_VERIFICATION_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.ADD_SIGNER_VERIFICATION_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Replace("{roleId}", roleId)
                 .Build();
@@ -41,7 +41,7 @@ namespace OneSpanSign.Sdk
 
         internal OneSpanSign.API.Verification GetSignerVerification( PackageId packageId, string roleId ) 
         {
-            string path = template.UrlFor( UrlTemplate.GET_SIGNER_VERIFICATION_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.GET_SIGNER_VERIFICATION_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Replace("{roleId}", roleId)
                 .Build();
@@ -63,7 +63,7 @@ namespace OneSpanSign.Sdk
 
         internal void UpdateSignerVerification( PackageId packageId, string roleId , OneSpanSign.API.Verification verification) 
         {
-            string path = template.UrlFor( UrlTemplate.UPDATE_SIGNER_VERIFICATION_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.UPDATE_SIGNER_VERIFICATION_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Replace("{roleId}", roleId)
                 .Build();
@@ -85,7 +85,7 @@ namespace OneSpanSign.Sdk
 
         internal void DeleteSignerVerification( PackageId packageId, string roleId ) 
         {
-            string path = template.UrlFor( UrlTemplate.DELETE_SIGNER_VERIFICATION_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.DELETE_SIGNER_VERIFICATION_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Replace("{roleId}", roleId)
                 .Build();

--- a/src/SDK/Services/SigningService.cs
+++ b/src/SDK/Services/SigningService.cs
@@ -7,20 +7,20 @@ namespace OneSpanSign.Sdk
 {
     public class SigningService
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings settings;
+        private string baseUrl;
 
         public SigningService(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
-            this.template = new UrlTemplate( baseUrl );
+            this.baseUrl = baseUrl;
             this.restClient = restClient;
             this.settings = settings;
         }
 
         internal void SignDocument( PackageId packageId, SignedDocument signedDocument ) 
         {
-            string path = template.UrlFor( UrlTemplate.SIGN_DOCUMENT_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.SIGN_DOCUMENT_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -41,7 +41,7 @@ namespace OneSpanSign.Sdk
 
         internal void SignDocuments( PackageId packageId, OneSpanSign.API.SignedDocuments documents ) 
         {
-            string path = template.UrlFor( UrlTemplate.SIGN_DOCUMENTS_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.SIGN_DOCUMENTS_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -62,7 +62,7 @@ namespace OneSpanSign.Sdk
 
         internal void SignDocuments( PackageId packageId, OneSpanSign.API.SignedDocuments documents, string signerSessionId ) 
         {
-            string path = template.UrlFor( UrlTemplate.SIGN_DOCUMENTS_PATH )
+            string path = new UrlTemplate(baseUrl).UrlFor( UrlTemplate.SIGN_DOCUMENTS_PATH )
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 

--- a/src/SDK/Services/SigningStyleService.cs
+++ b/src/SDK/Services/SigningStyleService.cs
@@ -9,20 +9,20 @@ namespace OneSpanSign.Sdk
 {
     public class SigningStyleService
     {
-        private UrlTemplate template;
         private RestClient restClient;
         private JsonSerializerSettings settings;
+        private string baseUrl;
 
         public SigningStyleService (RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
-            this.template = new UrlTemplate (baseUrl);
             this.restClient = restClient;
             this.settings = settings;
+            this.baseUrl = baseUrl;
         }
 
         public IDictionary<string, object> CreateSigningThemes (string signingThemesString)
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_THEME_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_THEME_PATH)
                           .Build ();
 
             try
@@ -42,7 +42,7 @@ namespace OneSpanSign.Sdk
 
         public IDictionary<string, object> GetSigningThemes ()
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_THEME_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_THEME_PATH)
                           .Build ();
 
             try
@@ -62,7 +62,7 @@ namespace OneSpanSign.Sdk
 
         public IDictionary<string, object> UpdateSigningThemes (string signingThemesString)
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_THEME_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_THEME_PATH)
                           .Build ();
 
             try
@@ -82,7 +82,7 @@ namespace OneSpanSign.Sdk
 
         public void DeleteSigningThemes ()
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_THEME_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_THEME_PATH)
                           .Build ();
 
             try 
@@ -101,7 +101,7 @@ namespace OneSpanSign.Sdk
 
         public void SaveSigningLogos (List<SigningLogo> signingLogos)
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_LOGO_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_LOGO_PATH)
                           .Build ();
             string payload = JsonConvert.SerializeObject (signingLogos, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver (), Formatting = Formatting.Indented });
 
@@ -121,7 +121,7 @@ namespace OneSpanSign.Sdk
 
         public List<SigningLogo> GetSigningLogos ()
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_LOGO_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_LOGO_PATH)
                           .Build ();
 
             try
@@ -141,7 +141,7 @@ namespace OneSpanSign.Sdk
 
         public SigningUiOptions GetSigningUiOptions()
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_UI_OPTIONS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_UI_OPTIONS_PATH)
                 .Build ();
 
             try
@@ -161,7 +161,7 @@ namespace OneSpanSign.Sdk
         
         public void SaveSigningUiOptions(SigningUiOptions signingUiOptions)
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_UI_OPTIONS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_UI_OPTIONS_PATH)
                 .Build ();
             string payload = JsonConvert.SerializeObject(signingUiOptions, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver (), Formatting = Formatting.Indented ,NullValueHandling = NullValueHandling.Ignore});
             try
@@ -180,7 +180,7 @@ namespace OneSpanSign.Sdk
         
         public void DeleteSigningUiOptions ()
         {
-            string path = template.UrlFor (UrlTemplate.ACCOUNT_SIGNING_UI_OPTIONS_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.ACCOUNT_SIGNING_UI_OPTIONS_PATH)
                 .Build ();
 
             try 

--- a/src/SDK/Services/SystemService.cs
+++ b/src/SDK/Services/SystemService.cs
@@ -7,20 +7,20 @@ namespace OneSpanSign.Sdk
 {
     public class SystemService
     {
-        private UrlTemplate template;
         private JsonSerializerSettings settings;
         private RestClient restClient;
+        private string baseUrl;
 
         public SystemService(RestClient restClient, string baseUrl, JsonSerializerSettings settings)
         {
             this.restClient = restClient;
-            template = new UrlTemplate(baseUrl);
             this.settings = settings;
+            this.baseUrl = baseUrl;
         }
 
         public string GetApplicationVersion() 
         {
-            string path = template.UrlFor(UrlTemplate.SYSTEM_PATH)
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.SYSTEM_PATH)
                 .Build();
 
             try

--- a/src/SDK/Services/VirtualRoomService.cs
+++ b/src/SDK/Services/VirtualRoomService.cs
@@ -7,13 +7,13 @@ namespace OneSpanSign.Sdk.Services
 {
     public class VirtualRoomService
     {
-        private UrlTemplate template;
         private RestClient restClient;
+        private string baseUrl;
 
         public VirtualRoomService(RestClient restClient, string baseUrl)
         {
             this.restClient = restClient;
-            template = new UrlTemplate(baseUrl);
+            this.baseUrl = baseUrl;
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace OneSpanSign.Sdk.Services
         /// <returns>Virtual Room.</returns>
         public VirtualRoom GetVirtualRoom(PackageId packageId)
         {
-            String path = template.UrlFor(UrlTemplate.VIRTUAL_ROOM_CONFIG_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.VIRTUAL_ROOM_CONFIG_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 
@@ -52,7 +52,7 @@ namespace OneSpanSign.Sdk.Services
         /// <param name="VirtualRoom">VirtualRoom.</param>
         public void SetVirtualRoom(PackageId packageId, VirtualRoom VirtualRoom)
         {
-            String path = template.UrlFor(UrlTemplate.VIRTUAL_ROOM_CONFIG_PATH)
+            String path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.VIRTUAL_ROOM_CONFIG_PATH)
                 .Replace("{packageId}", packageId.Id)
                 .Build();
 


### PR DESCRIPTION
This is to fix a race condition that was happening when re-using the same EslClient over and over.
The race condition was occurring when UrlTemplate.forUrl was updating the field path in the class and at one point passed the wrong value to the next caller.

What changed:

- Update all the classes save one that use the urlTemplate to create a new instance of the class per use rather than re-using the same one.