### PR TITLE
Update ApplicationLogger.cs to fix logging

### DIFF
--- a/src/SDK/Internal/ApplicationLogger.cs
+++ b/src/SDK/Internal/ApplicationLogger.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#define TRACE
+
+using System;
 using System.Diagnostics;
 
 namespace OneSpanSign.Sdk.Internal


### PR DESCRIPTION
 #63: Resolving issue where logging is broken because of missing TRACE compiler flag.
 
For reference: https://github.com/OneSpan/oss.sdk.net/issues/63