### PR TITLE
feat: PB-124936 Add SDK methods for the 'localize-consent' API

### DIFF
--- a/src/SDK/Internal/Conversion/ConsentLocalizationConverter.cs
+++ b/src/SDK/Internal/Conversion/ConsentLocalizationConverter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using OneSpanSign.API.Models;
+using OneSpanSign.Sdk.Models;
+
+namespace OneSpanSign.Sdk.Internal.Conversion
+{
+    public static class ConsentLocalizationConverter
+    {
+        public static ConsentLocalizationRequest ToApi(ConsentLocalizationPayload payload)
+        {
+            if (payload == null) throw new ArgumentNullException(nameof(payload));
+
+            if (string.IsNullOrWhiteSpace(payload.Language))
+            {
+                throw new ArgumentException("Language cannot be null or empty.", nameof(payload));
+            }
+
+            return new ConsentLocalizationRequest(payload.Language);
+        }
+    }
+}

--- a/src/SDK/Internal/UrlTemplate.cs
+++ b/src/SDK/Internal/UrlTemplate.cs
@@ -38,6 +38,7 @@ namespace OneSpanSign.Sdk.Internal
         public static readonly string NOTIFICATIONS_PATH = "/packages/{packageId}/notifications";
         public static readonly string PDF_PATH = "/packages/{packageId}/documents/{documentId}/pdf";
         public static readonly string ORIGINAL_PATH = "/packages/{packageId}/documents/{documentId}/original";
+        public static readonly string LOCALIZE_CONSENT_PATH = "/packages/{packageId}/documents/localize-consent";
         public static readonly string ZIP_PATH = "/packages/{packageId}/documents/zip";
         public static readonly string EVIDENCE_SUMMARY_PATH = "/packages/{packageId}/evidence/summary";
         public static readonly string SIGNING_STATUS_PATH = "/packages/{packageId}/signingStatus?signer={signerId}&document={documentId}";

--- a/src/SDK/Models/ConsentLocalizationData.cs
+++ b/src/SDK/Models/ConsentLocalizationData.cs
@@ -1,0 +1,38 @@
+﻿using System;
+
+namespace OneSpanSign.Sdk.Models
+{
+    [Serializable]
+    public class ConsentLocalizationData
+    {
+        public string ConsentId { get; set; }
+
+        public ConsentMetadataDetails ConsentMetadata { get; set; }
+
+        [Serializable]
+        public class ConsentMetadataDetails
+        {
+            public PackageInfo PackageInfo { get; set; }
+
+            public ResourceMetadata Properties { get; set; }
+
+            public ResourceMetadata Document { get; set; }
+        }
+
+        [Serializable]
+        public class PackageInfo
+        {
+            public string Uid { get; set; }
+
+            public string Language { get; set; }
+        }
+
+        [Serializable]
+        public class ResourceMetadata
+        {
+            public string AccountId { get; set; }
+
+            public string Language { get; set; }
+        }
+    }
+}

--- a/src/SDK/Models/ConsentLocalizationPayload.cs
+++ b/src/SDK/Models/ConsentLocalizationPayload.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace OneSpanSign.Sdk.Models
+{
+    [Serializable]
+    public class ConsentLocalizationPayload
+    {
+        public ConsentLocalizationPayload(string language)
+        {
+            Language = language ?? throw new ArgumentNullException(nameof(language));
+        }
+
+        public string Language { get; set; }
+    }
+}

--- a/src/SDK/Models/ConsentLocalizationRequest.cs
+++ b/src/SDK/Models/ConsentLocalizationRequest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Newtonsoft.Json;
+namespace OneSpanSign.API.Models
+{
+    [Serializable]
+    public class ConsentLocalizationRequest
+    {
+        public ConsentLocalizationRequest()
+        {
+        }
+
+        public ConsentLocalizationRequest(string language)
+        {
+            Language = language ?? throw new ArgumentNullException(nameof(language));
+        }
+
+        [JsonProperty("language")]
+        public string Language { get; set; }
+    }
+}

--- a/src/SDK/Models/PackageUpdateWorkflowResult.cs
+++ b/src/SDK/Models/PackageUpdateWorkflowResult.cs
@@ -37,13 +37,13 @@ namespace OneSpanSign.Sdk.Models
             {
             }
 
-            public ConsentLocalizationResult(Status status, string message, ConsentLocalizationData data)
+            public ConsentLocalizationResult(Status status, string message, ConsentLocalizationData consentData)
                 : base(status, message)
             {
-                Data = data;
+                ConsentData = consentData;
             }
 
-            public ConsentLocalizationData Data { get; set; }
+            public ConsentLocalizationData ConsentData { get; set; }
         }
 
         public string PackageUid { get; set; }

--- a/src/SDK/Models/PackageUpdateWorkflowResult.cs
+++ b/src/SDK/Models/PackageUpdateWorkflowResult.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+namespace OneSpanSign.Sdk.Models
+{
+    [Serializable]
+    public class PackageUpdateWorkflowResult
+    {
+        public enum Status
+        {
+            SUCCESS,
+            FAILURE,
+            SKIPPED
+        }
+
+        [Serializable]
+        public class Result
+        {
+            public Result()
+            {
+            }
+
+            public Result(Status status, string message)
+            {
+                Status = status;
+                Message = message;
+            }
+
+            public Status Status { get; set; }
+
+            public string Message { get; set; }
+        }
+
+        [Serializable]
+        public class ConsentLocalizationResult : Result
+        {
+            public ConsentLocalizationResult()
+            {
+            }
+
+            public ConsentLocalizationResult(Status status, string message, ConsentLocalizationData data)
+                : base(status, message)
+            {
+                Data = data;
+            }
+
+            public ConsentLocalizationData Data { get; set; }
+        }
+
+        public string PackageUid { get; set; }
+
+        public ConsentLocalizationResult ConsentInfo { get; set; }
+    }
+}

--- a/src/SDK/OssClient.cs
+++ b/src/SDK/OssClient.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using OneSpanSign.Sdk.Builder.Internal;
+using OneSpanSign.Sdk.Models;
 using OneSpanSign.Sdk.Oauth;
 
 namespace OneSpanSign.Sdk
@@ -567,6 +568,16 @@ namespace OneSpanSign.Sdk
         public void UpdatePackage(OneSpanSign.Sdk.PackageId packageId, DocumentPackage documentPackage)
         {
             packageService.UpdatePackage(packageId, new DocumentPackageConverter(documentPackage).ToAPIPackage());
+        }
+
+        public PackageUpdateWorkflowResult UpdatePackageAndLocalizeConsent(OneSpanSign.Sdk.PackageId packageId, DocumentPackage documentPackage)
+        {
+            return packageService.UpdatePackageAndLocalizeConsent(packageId, new DocumentPackageConverter(documentPackage).ToAPIPackage());
+        }
+
+        public ConsentLocalizationData LocalizeConsent(PackageId packageId, string language)
+        {
+            return packageService.LocalizeDefaultConsentDocument(packageId, new ConsentLocalizationPayload(language));
         }
 
         public void ChangePackageStatusToDraft(PackageId packageId)

--- a/src/SDK/Services/PackageService.cs
+++ b/src/SDK/Services/PackageService.cs
@@ -558,12 +558,17 @@ namespace OneSpanSign.Sdk.Services
         
         /// <summary>
         /// Updates the package's fields and automatically localizes the default consent document
-        /// if the language has changed.
+        /// if the language has changed. The method returns a workflow result describing both the
+        /// package update and the outcome of consent localization:
+        ///
+        /// - If the package is updated and the language has changed, the consent document is localized and the result contains the localization outcome.
+        /// - If the language did not change, the result indicates that consent localization was skipped.
+        /// - If the update or localization fails, the result contains error information.
         /// </summary>
-        /// <param name="packageId">The ID of the package to update.</param>
-        /// <param name="sdkPackage">The package containing updated fields and language.</param>
+        /// <param name="packageId">The ID of the package to update. Must not be null.</param>
+        /// <param name="package">The package containing updated fields and language.</param>
         /// <returns>
-        /// Workflow result describing package update and consent localization outcomes.
+        /// Workflow result describing package update and consent localization outcomes, including status and messages for each step.
         /// </returns>
         /// <exception cref="EslException">
         /// Thrown when the package update operation fails with a server‑side error.
@@ -626,11 +631,15 @@ namespace OneSpanSign.Sdk.Services
         }
                 
         /// <summary>
-        /// Attempts to localize the consent document for a package and updates the workflow result.
+        /// Attempts to localize the consent document for a package and updates the provided workflow result.
+        /// <para>
+        /// On success, updates the result with a ConsentLocalizationResult containing the localized consent data.
+        /// On failure, updates the result with a ConsentLocalizationResult indicating failure and an error message.
+        /// </para>
         /// </summary>
-        /// <param name="packageId">The package identifier.</param>
-        /// <param name="language">The language for localization.</param>
-        /// <param name="result">The workflow result to update.</param>
+        /// <param name="packageId">The package identifier. Must not be null.</param>
+        /// <param name="language">The language code for localization. Must not be null or empty.</param>
+        /// <param name="result">The workflow result object to update with the localization outcome.</param>
         private void LocalizeConsent(PackageId packageId, string language, PackageUpdateWorkflowResult result)
         {
             try

--- a/src/SDK/Services/PackageService.cs
+++ b/src/SDK/Services/PackageService.cs
@@ -11,6 +11,10 @@ using System.Globalization;
 using Newtonsoft.Json.Serialization;
 using System.Collections.Specialized;
 using System.Linq;
+using OneSpanSign.API.Models;
+using OneSpanSign.Sdk.Internal.Conversion;
+using OneSpanSign.Sdk.Models;
+using Converter = OneSpanSign.Sdk.Internal.Converter;
 
 namespace OneSpanSign.Sdk.Services
 {
@@ -20,13 +24,15 @@ namespace OneSpanSign.Sdk.Services
     /// </summary>
     public class PackageService
     {
+        private static ILogger log = LoggerFactory.get(typeof(PackageService));
+        
         private JsonSerializerSettings settings;
         private RestClient restClient;
         private ReportService reportService;
         private string baseUrl;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="OneSpanSign.Sdk.PackageService"/> class.
+        /// Initializes a new instance of the <see cref="PackageService"/> class.
         /// </summary>
         /// <param name="apiToken">API token.</param>
         /// <param name="baseUrl">Base URL.</param>
@@ -549,6 +555,142 @@ namespace OneSpanSign.Sdk.Services
                 throw new OssException("Unable to update package settings." + " Exception: " + e.Message, e);
             }
         }
+        
+        /// <summary>
+        /// Updates the package's fields and automatically localizes the default consent document
+        /// if the language has changed.
+        /// </summary>
+        /// <param name="packageId">The ID of the package to update.</param>
+        /// <param name="sdkPackage">The package containing updated fields and language.</param>
+        /// <returns>
+        /// Workflow result describing package update and consent localization outcomes.
+        /// </returns>
+        /// <exception cref="EslException">
+        /// Thrown when the package update operation fails with a server‑side error.
+        /// </exception>
+        internal PackageUpdateWorkflowResult UpdatePackageAndLocalizeConsent(
+            PackageId packageId, Package package)
+        {
+            if (packageId == null) throw new ArgumentNullException(nameof(packageId));
+            
+            string path = new UrlTemplate(baseUrl).UrlFor(UrlTemplate.PACKAGE_ID_PATH)
+                .Replace("{packageId}", packageId.Id)
+                .Build();
+
+            var result = new PackageUpdateWorkflowResult
+            {
+                PackageUid = packageId.Id
+            };
+
+            // Retrieve existing package to compare language later
+            Package existingPackage = TryGetPackage(packageId);
+            try
+            {
+                restClient.Put(path, JsonConvert.SerializeObject(package, settings));
+            }
+            catch (OssServerException e)
+            {
+                throw new OssServerException("Unable to update package settings." + " Exception: " + e.Message, e.ServerError, e);
+            }
+            catch (Exception e)
+            {
+                throw new OssException("Unable to update package settings." + " Exception: " + e.Message, e);
+            }
+            
+            // Retrieve updated package to compare language later
+            Package updatedPackage = TryGetPackage(packageId);
+            if (updatedPackage == null)
+            {
+                result.ConsentInfo = new PackageUpdateWorkflowResult.ConsentLocalizationResult(
+                    PackageUpdateWorkflowResult.Status.SKIPPED,
+                    "Consent localization could not be determined.",
+                    null);
+
+                return result;
+            }
+
+            if (existingPackage != null &&
+                string.Equals(updatedPackage.Language, existingPackage.Language, StringComparison.OrdinalIgnoreCase))
+            {
+                result.ConsentInfo = new PackageUpdateWorkflowResult.ConsentLocalizationResult(
+                    PackageUpdateWorkflowResult.Status.SKIPPED,
+                    "Consent localization not required because language did not change.",
+                    null);
+
+                return result;
+            }
+
+            // Localize consent if language changed or was newly set
+            LocalizeConsent(packageId, updatedPackage.Language, result);
+            return result;
+        }
+                
+        /// <summary>
+        /// Attempts to localize the consent document for a package and updates the workflow result.
+        /// </summary>
+        /// <param name="packageId">The package identifier.</param>
+        /// <param name="language">The language for localization.</param>
+        /// <param name="result">The workflow result to update.</param>
+        private void LocalizeConsent(PackageId packageId, string language, PackageUpdateWorkflowResult result)
+        {
+            try
+            {
+                var consentResponse = LocalizeDefaultConsentDocument(packageId, new ConsentLocalizationPayload(language));
+                var consentStep = new PackageUpdateWorkflowResult.ConsentLocalizationResult(
+                    PackageUpdateWorkflowResult.Status.SUCCESS,
+                    "Consent document localized successfully.",
+                    consentResponse
+                );
+                result.ConsentInfo = consentStep;
+            }
+            catch (Exception e)
+            {
+                // Optionally log the error here, e.g. _logger?.LogWarning(e, "Failed to localize default consent.");
+                var consentStep = new PackageUpdateWorkflowResult.ConsentLocalizationResult(
+                    PackageUpdateWorkflowResult.Status.FAILURE,
+                    "Failed to localize default consent: " + e.Message,
+                    null
+                );
+                result.ConsentInfo = consentStep;
+            }
+        }
+
+        /// <summary>
+        /// Localizes the consent document for a package.
+        /// </summary>
+        /// <param name="packageId">The package identifier (must not be null).</param>
+        /// <param name="localizationPayload">The localization details (language must not be null).</param>
+        /// <returns>ConsentLocalizationData</returns>
+        /// <exception cref="EslServerException">If the server returns an error.</exception>
+        /// <exception cref="EslException">For other exceptions.</exception>
+        internal ConsentLocalizationData LocalizeDefaultConsentDocument(PackageId packageId, ConsentLocalizationPayload localizationPayload)
+        {
+            if (localizationPayload == null) throw new ArgumentNullException(nameof(localizationPayload));
+            if (packageId == null) throw new ArgumentNullException(nameof(packageId));
+
+            string path = new UrlTemplate(baseUrl)
+                .UrlFor(UrlTemplate.LOCALIZE_CONSENT_PATH)
+                .Replace("{packageId}", packageId.Id)
+                .Build();
+
+            try
+            {
+                ConsentLocalizationRequest localizationRequest = ConsentLocalizationConverter.ToApi(localizationPayload);
+                string json = JsonConvert.SerializeObject(localizationRequest);
+
+                string response = restClient.Post(path, json);
+                return JsonConvert.DeserializeObject<ConsentLocalizationData>(response);
+            }
+            catch (OssServerException e)
+            {
+                throw new OssServerException("Could not localize consent document.", e);
+            }
+            catch (Exception e)
+            {
+                throw new OssException("Could not localize consent document. Exception: " + e.Message, e);
+            }
+        }
+    
 
         internal void ChangePackageStatusToDraft(PackageId packageId) 
         {
@@ -1083,7 +1225,7 @@ namespace OneSpanSign.Sdk.Services
             string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.PACKAGE_FIELDS_LIST_PATH)
                 .Replace ("{status}", new PackageStatusConverter (status).ToAPIPackageStatus ())
                 .Replace ("{from}", request.From.ToString ())
-                .Replace ("{to}", request.To.ToString ())
+                .Replace ("{to}", request.ToString ())
                 .Replace ("{fields}", string.Join(",", fields))
                 .Build ();
 
@@ -1733,5 +1875,33 @@ namespace OneSpanSign.Sdk.Services
                 throw new OssException ("Could not get referenced conditions." + " Exception: " + e.Message, e);
             }
         }
+
+        /// <summary>
+        /// Attempts to retrieve the package for the specified package ID.
+        /// Returns null if any error occurs.
+        /// </summary>
+        /// <param name="packageId">The package ID.</param>
+        /// <returns>The Package if successful; otherwise, null.</returns>
+        private Package TryGetPackage(PackageId packageId)
+        {
+            if (packageId == null || string.IsNullOrWhiteSpace(packageId.Id))
+                return null;
+
+            try
+            {
+                string path = new UrlTemplate(baseUrl)
+                    .UrlFor(UrlTemplate.PACKAGE_ID_PATH)
+                    .Replace("{packageId}", packageId.Id)
+                    .Build();
+
+                return GetApiPackageWithPath(path);
+            }
+            catch (Exception e)
+            {
+                log.Warn("Failed to get package!", e);
+                return null;
+            }
+        }
     }
 }
+

--- a/src/SDK/Services/PackageService.cs
+++ b/src/SDK/Services/PackageService.cs
@@ -1225,7 +1225,7 @@ namespace OneSpanSign.Sdk.Services
             string path = new UrlTemplate(baseUrl).UrlFor (UrlTemplate.PACKAGE_FIELDS_LIST_PATH)
                 .Replace ("{status}", new PackageStatusConverter (status).ToAPIPackageStatus ())
                 .Replace ("{from}", request.From.ToString ())
-                .Replace ("{to}", request.ToString ())
+                .Replace ("{to}", request.To.ToString ())
                 .Replace ("{fields}", string.Join(",", fields))
                 .Build ();
 

--- a/src/Samples.Tests/Tests/LocalizeConsentPackageExampleTest.cs
+++ b/src/Samples.Tests/Tests/LocalizeConsentPackageExampleTest.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+using OneSpanSign.Sdk.Models;
+
+namespace SDK.Examples
+{
+    public class LocalizeConsentPackageExampleTest
+    {
+        [Test]
+        public void verify() {
+        
+            LocalizeConsentPackageExample example = new LocalizeConsentPackageExample();
+            example.Run();
+            ConsentLocalizationData response = example.result;
+            
+            Assert.NotNull(response);
+            Assert.AreEqual("default-consent", response.ConsentId);
+            Assert.AreEqual(example.PackageId.Id, response.ConsentMetadata.PackageInfo.Uid);
+            Assert.AreEqual(example.OLD_LANGUAGE, response.ConsentMetadata.PackageInfo.Language);
+            Assert.AreEqual("esignlive", response.ConsentMetadata.Properties.AccountId);
+            Assert.AreEqual(example.NEW_LANGUAGE, response.ConsentMetadata.Properties.Language);
+            Assert.AreEqual("esignlive", response.ConsentMetadata.Document.AccountId);
+            Assert.AreEqual(example.NEW_LANGUAGE, response.ConsentMetadata.Document.Language);
+        }
+    }
+}

--- a/src/Samples.Tests/Tests/UpdatePackageAndLocalizeConsentDefaultLanguageExampleTest.cs
+++ b/src/Samples.Tests/Tests/UpdatePackageAndLocalizeConsentDefaultLanguageExampleTest.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using OneSpanSign.Sdk;
+using OneSpanSign.Sdk.Models;
+
+namespace SDK.Examples
+{
+    public class UpdatePackageAndLocalizeConsentDefaultLanguageExampleTest
+    {
+        [Test]
+        public void verify() {
+       
+            UpdatePackageAndLocalizeConsentDefaultLanguageExample example = new UpdatePackageAndLocalizeConsentDefaultLanguageExample();
+            example.Run();
+
+            assertPackage(example.createdPackage, example.packageToCreate);
+            assertWorkflowResult(example.updateWorkflowResult, example.createdPackage);
+        }
+
+        private void assertPackage(DocumentPackage actualPackage, DocumentPackage expectedPackage) {
+            Assert.AreEqual( expectedPackage.Name, actualPackage.Name );
+            Assert.AreEqual( expectedPackage.Language, actualPackage.Language );
+        }
+        
+        private void assertWorkflowResult(PackageUpdateWorkflowResult response, DocumentPackage createdPackage) {
+            
+            Assert.NotNull(response);
+            Assert.AreEqual(createdPackage.Id.Id, response.PackageUid);
+            Assert.NotNull(response.ConsentInfo);
+            Assert.AreEqual(PackageUpdateWorkflowResult.Status.SKIPPED, response.ConsentInfo.Status);
+            Assert.AreEqual("Consent localization not required because language did not change.", response.ConsentInfo.Message);
+            Assert.Null(response.ConsentInfo.Data);
+
+        }
+    }
+}

--- a/src/Samples.Tests/Tests/UpdatePackageAndLocalizeConsentDefaultLanguageExampleTest.cs
+++ b/src/Samples.Tests/Tests/UpdatePackageAndLocalizeConsentDefaultLanguageExampleTest.cs
@@ -28,7 +28,7 @@ namespace SDK.Examples
             Assert.NotNull(response.ConsentInfo);
             Assert.AreEqual(PackageUpdateWorkflowResult.Status.SKIPPED, response.ConsentInfo.Status);
             Assert.AreEqual("Consent localization not required because language did not change.", response.ConsentInfo.Message);
-            Assert.Null(response.ConsentInfo.Data);
+            Assert.Null(response.ConsentInfo.ConsentData);
 
         }
     }

--- a/src/Samples.Tests/Tests/UpdatePackageAndLocalizeConsentExampleTest.cs
+++ b/src/Samples.Tests/Tests/UpdatePackageAndLocalizeConsentExampleTest.cs
@@ -26,13 +26,13 @@ namespace SDK.Examples
             Assert.NotNull(response);
             Assert.NotNull(response.ConsentInfo);
             Assert.AreEqual(createdPackage.Id.Id, response.PackageUid);
-            Assert.AreEqual("default-consent", response.ConsentInfo.Data.ConsentId);
-            Assert.AreEqual(createdPackage.Id.Id, response.ConsentInfo.Data.ConsentMetadata.PackageInfo.Uid);
-            Assert.AreEqual("fr", response.ConsentInfo.Data.ConsentMetadata.PackageInfo.Language);
-            Assert.AreEqual("esignlive", response.ConsentInfo.Data.ConsentMetadata.Properties.AccountId);
-            Assert.AreEqual("fr", response.ConsentInfo.Data.ConsentMetadata.Properties.Language);
-            Assert.AreEqual("esignlive", response.ConsentInfo.Data.ConsentMetadata.Document.AccountId);
-            Assert.AreEqual("fr", response.ConsentInfo.Data.ConsentMetadata.Document.Language);
+            Assert.AreEqual("default-consent", response.ConsentInfo.ConsentData.ConsentId);
+            Assert.AreEqual(createdPackage.Id.Id, response.ConsentInfo.ConsentData.ConsentMetadata.PackageInfo.Uid);
+            Assert.AreEqual("fr", response.ConsentInfo.ConsentData.ConsentMetadata.PackageInfo.Language);
+            Assert.AreEqual("esignlive", response.ConsentInfo.ConsentData.ConsentMetadata.Properties.AccountId);
+            Assert.AreEqual("fr", response.ConsentInfo.ConsentData.ConsentMetadata.Properties.Language);
+            Assert.AreEqual("esignlive", response.ConsentInfo.ConsentData.ConsentMetadata.Document.AccountId);
+            Assert.AreEqual("fr", response.ConsentInfo.ConsentData.ConsentMetadata.Document.Language);
 
         }
     }

--- a/src/Samples.Tests/Tests/UpdatePackageAndLocalizeConsentExampleTest.cs
+++ b/src/Samples.Tests/Tests/UpdatePackageAndLocalizeConsentExampleTest.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+using OneSpanSign.Sdk;
+using OneSpanSign.Sdk.Models;
+
+namespace SDK.Examples
+{
+    public class UpdatePackageAndLocalizeConsentExampleTest
+    {
+        [Test]
+        public void verify() {
+       
+            UpdatePackageAndLocalizeConsentExample example = new UpdatePackageAndLocalizeConsentExample();
+            example.Run();
+
+            assertPackage(example.createdPackage, example.packageToCreate);
+            assertWorkflowResult(example.updateWorkflowResult, example.createdPackage);
+        }
+
+        private void assertPackage(DocumentPackage actualPackage, DocumentPackage expectedPackage) {
+            Assert.AreEqual( expectedPackage.Name, actualPackage.Name );
+            Assert.AreEqual( expectedPackage.Language, actualPackage.Language );
+        }
+        
+        private void assertWorkflowResult(PackageUpdateWorkflowResult response, DocumentPackage createdPackage) {
+            
+            Assert.NotNull(response);
+            Assert.NotNull(response.ConsentInfo);
+            Assert.AreEqual(createdPackage.Id.Id, response.PackageUid);
+            Assert.AreEqual("default-consent", response.ConsentInfo.Data.ConsentId);
+            Assert.AreEqual(createdPackage.Id.Id, response.ConsentInfo.Data.ConsentMetadata.PackageInfo.Uid);
+            Assert.AreEqual("fr", response.ConsentInfo.Data.ConsentMetadata.PackageInfo.Language);
+            Assert.AreEqual("esignlive", response.ConsentInfo.Data.ConsentMetadata.Properties.AccountId);
+            Assert.AreEqual("fr", response.ConsentInfo.Data.ConsentMetadata.Properties.Language);
+            Assert.AreEqual("esignlive", response.ConsentInfo.Data.ConsentMetadata.Document.AccountId);
+            Assert.AreEqual("fr", response.ConsentInfo.Data.ConsentMetadata.Document.Language);
+
+        }
+    }
+}

--- a/src/Samples.Tests/Tests/UpdatePackageExampleTest.cs
+++ b/src/Samples.Tests/Tests/UpdatePackageExampleTest.cs
@@ -9,6 +9,7 @@ namespace SDK.Examples
     {
         [Test]
         public void verify() {
+            // Asserts that are commented out are so because updating them is not currently supported by the oss server.
         
             UpdatePackageExample example = new UpdatePackageExample();
             example.Run();

--- a/src/Samples.Tests/Tests/UpdatePackageExampleTest.cs
+++ b/src/Samples.Tests/Tests/UpdatePackageExampleTest.cs
@@ -9,7 +9,6 @@ namespace SDK.Examples
     {
         [Test]
         public void verify() {
-            // Asserts that are commented out are so because updating them is not currently supported by the oss server.
         
             UpdatePackageExample example = new UpdatePackageExample();
             example.Run();

--- a/src/Samples/Examples/LocalizeConsentPackageExample.cs
+++ b/src/Samples/Examples/LocalizeConsentPackageExample.cs
@@ -1,0 +1,33 @@
+using OneSpanSign.Sdk;
+using OneSpanSign.Sdk.Builder;
+using System.Globalization;
+using OneSpanSign.Sdk.Models;
+
+namespace SDK.Examples
+{
+    public class LocalizeConsentPackageExample : SDKSample
+    {
+        public static void Main(string[] args)
+        {
+            new UpdatePackageExample().Run();
+        }
+
+        public readonly string INITIAL_PACKAGE_NAME = "Package Name";
+        public readonly string OLD_LANGUAGE = "en";
+        public readonly string NEW_LANGUAGE = "fr";
+        
+
+        public DocumentPackage packageToCreate;
+        public ConsentLocalizationData result;
+
+        override public void Execute()
+        {
+            packageToCreate = PackageBuilder.NewPackageNamed(INITIAL_PACKAGE_NAME)
+                                          .WithLanguage(CultureInfo.GetCultureInfo("en"))
+                                          .Build();
+
+            packageId = ossClient.CreatePackage(packageToCreate);
+            result = ossClient.LocalizeConsent(packageId, NEW_LANGUAGE);
+        }
+    }
+}

--- a/src/Samples/Examples/UpdatePackageAndLocalizeConsentDefaultLanguageExample.cs
+++ b/src/Samples/Examples/UpdatePackageAndLocalizeConsentDefaultLanguageExample.cs
@@ -16,7 +16,6 @@ namespace SDK.Examples
         public readonly string UPDATED_PACKAGE_NAME = "New Package Name";
         public readonly CultureInfo OLD_LANGUAGE = CultureInfo.GetCultureInfo("en");
         public readonly CultureInfo NEW_LANGUAGE = CultureInfo.GetCultureInfo("tst");
-        
 
         public DocumentPackage packageToCreate, packageToUpdate, createdPackage;
         public PackageUpdateWorkflowResult updateWorkflowResult;

--- a/src/Samples/Examples/UpdatePackageAndLocalizeConsentDefaultLanguageExample.cs
+++ b/src/Samples/Examples/UpdatePackageAndLocalizeConsentDefaultLanguageExample.cs
@@ -1,0 +1,39 @@
+using OneSpanSign.Sdk;
+using OneSpanSign.Sdk.Builder;
+using System.Globalization;
+using OneSpanSign.Sdk.Models;
+
+namespace SDK.Examples
+{
+    public class UpdatePackageAndLocalizeConsentDefaultLanguageExample : SDKSample
+    {
+        public static void Main(string[] args)
+        {
+            new UpdatePackageExample().Run();
+        }
+
+        public readonly string INITIAL_PACKAGE_NAME = "Package Name";
+        public readonly string UPDATED_PACKAGE_NAME = "New Package Name";
+        public readonly CultureInfo OLD_LANGUAGE = CultureInfo.GetCultureInfo("en");
+        public readonly CultureInfo NEW_LANGUAGE = CultureInfo.GetCultureInfo("tst");
+        
+
+        public DocumentPackage packageToCreate, packageToUpdate, createdPackage;
+        public PackageUpdateWorkflowResult updateWorkflowResult;
+
+        override public void Execute()
+        {
+            packageToCreate = PackageBuilder.NewPackageNamed(INITIAL_PACKAGE_NAME)
+                                          .WithLanguage(OLD_LANGUAGE)
+                                          .Build();
+
+            packageId = ossClient.CreatePackage(packageToCreate);
+            createdPackage = ossClient.GetPackage( packageId );
+
+            packageToUpdate = PackageBuilder.NewPackageNamed(UPDATED_PACKAGE_NAME)
+                               .WithLanguage(NEW_LANGUAGE)
+                               .Build();
+            updateWorkflowResult = ossClient.UpdatePackageAndLocalizeConsent(packageId, packageToUpdate);
+        }
+    }
+}

--- a/src/Samples/Examples/UpdatePackageAndLocalizeConsentExample.cs
+++ b/src/Samples/Examples/UpdatePackageAndLocalizeConsentExample.cs
@@ -1,0 +1,39 @@
+using OneSpanSign.Sdk;
+using OneSpanSign.Sdk.Builder;
+using System.Globalization;
+using OneSpanSign.Sdk.Models;
+
+namespace SDK.Examples
+{
+    public class UpdatePackageAndLocalizeConsentExample : SDKSample
+    {
+        public static void Main(string[] args)
+        {
+            new UpdatePackageExample().Run();
+        }
+
+        public readonly string INITIAL_PACKAGE_NAME = "Package Name";
+        public readonly string UPDATED_PACKAGE_NAME = "New Package Name";
+        public readonly CultureInfo OLD_LANGUAGE = CultureInfo.GetCultureInfo("en");
+        public readonly CultureInfo NEW_LANGUAGE = CultureInfo.GetCultureInfo("fr");
+        
+
+        public DocumentPackage packageToCreate, packageToUpdate, createdPackage;
+        public PackageUpdateWorkflowResult updateWorkflowResult;
+
+        override public void Execute()
+        {
+            packageToCreate = PackageBuilder.NewPackageNamed(INITIAL_PACKAGE_NAME)
+                                          .WithLanguage(OLD_LANGUAGE)
+                                          .Build();
+
+            packageId = ossClient.CreatePackage(packageToCreate);
+            createdPackage = ossClient.GetPackage( packageId );
+
+            packageToUpdate = PackageBuilder.NewPackageNamed(UPDATED_PACKAGE_NAME)
+                               .WithLanguage(NEW_LANGUAGE)
+                               .Build();
+            updateWorkflowResult = ossClient.UpdatePackageAndLocalizeConsent(packageId, packageToUpdate);
+        }
+    }
+}

--- a/src/Samples/Examples/UpdatePackageAndLocalizeConsentExample.cs
+++ b/src/Samples/Examples/UpdatePackageAndLocalizeConsentExample.cs
@@ -17,7 +17,6 @@ namespace SDK.Examples
         public readonly CultureInfo OLD_LANGUAGE = CultureInfo.GetCultureInfo("en");
         public readonly CultureInfo NEW_LANGUAGE = CultureInfo.GetCultureInfo("fr");
         
-
         public DocumentPackage packageToCreate, packageToUpdate, createdPackage;
         public PackageUpdateWorkflowResult updateWorkflowResult;
 


### PR DESCRIPTION
Test execution against OSSQ1:
<img width="1303" height="284" alt="image" src="https://github.com/user-attachments/assets/019b9188-6196-4bc0-8c00-19c4bd7a80cf" />
