### PR TITLE
feat: PB-126495 Add designerReadOnly property to Document

### DIFF
--- a/src/SDK.Tests/Internal/Conversion/DocumentConverterTest.cs
+++ b/src/SDK.Tests/Internal/Conversion/DocumentConverterTest.cs
@@ -132,6 +132,31 @@ namespace SDK.Tests
         }
 
         [Test()]
+        public void ConvertToAPIWithDesignerReadOnly()
+        {
+            sdkDocument1 = DocumentBuilder.NewDocumentNamed( "sdkDocument" )
+                    .WithId( "sdkDocumentId" )
+                    .FromFile(file.FullName)
+                    .WithDesignerReadOnly(true)
+                    .Build();
+
+            apiDocument1 = new DocumentConverter(sdkDocument1).ToAPIDocument();
+
+            Assert.AreEqual(true, apiDocument1.DesignerReadOnly);
+        }
+
+        [Test()]
+        public void ConvertToSDKWithDesignerReadOnly()
+        {
+            apiDocument1 = CreateTypicalAPIDocument();
+            apiDocument1.DesignerReadOnly = true;
+
+            sdkDocument1 = new DocumentConverter(apiDocument1, apiPackage).ToSDKDocument();
+
+            Assert.AreEqual(true, sdkDocument1.DesignerReadOnly);
+        }
+
+        [Test()]
         public void ConvertToAPIWithBase64Content()
         {
             sdkDocument1 = DocumentBuilder.NewDocumentNamed( "sdkDocumentNullDes" )

--- a/src/SDK/Builder/DocumentBuilder.cs
+++ b/src/SDK/Builder/DocumentBuilder.cs
@@ -21,6 +21,7 @@ namespace OneSpanSign.Sdk.Builder
         private External external;
         private IDictionary<string, object> data = new Dictionary<string, object>();
 		private string base64Content;
+        private Nullable<Boolean> designerReadOnly;
 
 		private DocumentBuilder(string name)
 		{
@@ -146,9 +147,15 @@ namespace OneSpanSign.Sdk.Builder
             return this;
         }
 
-        public DocumentBuilder WithExtractionType(ExtractionType extractionType) 
+        public DocumentBuilder WithExtractionType(ExtractionType extractionType)
         {
             this.extractionTypes.Add(extractionType.ToString());
+            return this;
+        }
+
+        public DocumentBuilder WithDesignerReadOnly(bool designerReadOnly)
+        {
+            this.designerReadOnly = designerReadOnly;
             return this;
         }
 
@@ -171,6 +178,7 @@ namespace OneSpanSign.Sdk.Builder
 			doc.Description = description;
             doc.Data = data;
 			doc.Base64Content = base64Content;
+            doc.DesignerReadOnly = designerReadOnly;
 
 			return doc;
 		}

--- a/src/SDK/Document.cs
+++ b/src/SDK/Document.cs
@@ -49,6 +49,11 @@ namespace OneSpanSign.Sdk
             set;
         }
 
+        public Nullable<Boolean> DesignerReadOnly {
+            get;
+            set;
+        }
+
         public List<string> ExtractionTypes {
             get;
             set;

--- a/src/SDK/Internal/Conversion/DocumentConverter.cs
+++ b/src/SDK/Internal/Conversion/DocumentConverter.cs
@@ -65,9 +65,14 @@ namespace OneSpanSign.Sdk
                 document.NumberOfPages = apiDocument.Pages.Count;
             }
 
-            if ( apiDocument.Tagged != null ) 
+            if ( apiDocument.Tagged != null )
             {
                 document.Tagged = apiDocument.Tagged;
+            }
+
+            if ( apiDocument.DesignerReadOnly != null )
+            {
+                document.DesignerReadOnly = apiDocument.DesignerReadOnly;
             }
 
             if ( apiDocument.ExternalSigned != null )
@@ -140,6 +145,7 @@ namespace OneSpanSign.Sdk
             doc.External = new ExternalConverter(sdkDocument.External).ToAPIExternal();
             doc.Data = sdkDocument.Data;
             doc.Tagged = sdkDocument.Tagged;
+            doc.DesignerReadOnly = sdkDocument.DesignerReadOnly;
 
             if (sdkDocument.Id != null)
             {

--- a/src/SDK/Models/Document.cs
+++ b/src/SDK/Models/Document.cs
@@ -86,6 +86,12 @@ namespace OneSpanSign.API
         {
             get; set;
         }
+
+        [JsonProperty("designerReadOnly")]
+        public Nullable<Boolean> DesignerReadOnly
+        {
+            get; set;
+        }
     
 		    
         [JsonProperty("extractionTypes")]


### PR DESCRIPTION
## What

Adds the new `designerReadOnly` Boolean property to Document, matching the backend API contract.

- `Models/Document.cs` — `[JsonProperty("designerReadOnly")] Nullable<Boolean> DesignerReadOnly` (omitted from JSON when unset, via the client's `NullValueHandling.Ignore`)
- `Document.cs` — public SDK model property
- `DocumentConverter.cs` — mapped in both directions
- `DocumentBuilder.cs` — new `WithDesignerReadOnly(bool)` fluent method

## Testing

- Two new round-trip tests in `DocumentConverterTest` (SDK→API and API→SDK); all 816 tests pass on `net10.0`. The `net48` target was not built locally (requires Windows) — same source, CI should cover it.

Companion PR for the Java SDK: OneSpan/esl.sdk.java#197

Generated with Claude Code